### PR TITLE
Add tabulate for simple and common table cases

### DIFF
--- a/core/src/main/scala/com/github/johnynek/paiges/Doc.scala
+++ b/core/src/main/scala/com/github/johnynek/paiges/Doc.scala
@@ -447,7 +447,6 @@ sealed abstract class Doc extends Product with Serializable {
     def loop(h: DB, stack: List[DB], front: List[DB]): DB =
       h._1 match {
         case Empty | Text(_) =>
-          val noChange = h
           stack match {
             case Nil => finish(h, front)
             case x :: xs => loop(x, xs, h :: front)
@@ -849,7 +848,6 @@ object Doc {
     if (kv.isEmpty) empty
     else {
       val fills = kv.iterator.map(_._1.length).max
-      val width = leftSep.length + fills + rightSep.length
       val leftD = Doc.text(leftSep)
       val rightD = Doc.text(rightSep)
       def keyToDoc(s: String): Doc = Doc.text(s) + leftD + Doc.char(fill).repeat(fills - s.length) + rightD

--- a/core/src/main/scala/com/github/johnynek/paiges/Doc.scala
+++ b/core/src/main/scala/com/github/johnynek/paiges/Doc.scala
@@ -843,28 +843,26 @@ object Doc {
    * A simple table which is the same as:
    * tabulate("", ' ', "", kv)
    *
-   * or, no left or right separator and a space as the fill
+   * or, no right separator and a space as the fill
    */
   def tabulate(kv: List[(String, Doc)]): Doc =
-    tabulate("", ' ', "", kv)
+    tabulate(' ', "", kv)
 
   /**
    * build a table with the strings left aligned and
    * the Docs starting in the column after the longest string.
    * The Docs on the right are rendered aligned after the rightSep
    *
-   * @param leftSep a string appended on the end of the key
    * @param fill the character used to fill the columns to make the values aligned (i.e. ' ' or '.')
    * @param rightSep a string append left to the left of the value. Intended for use with bullets on values
    * @param kv a List of key, value pairs to put in a table.
    */
-  def tabulate(leftSep: String, fill: Char, rightSep: String, kv: List[(String, Doc)]): Doc =
-    if (kv.isEmpty) empty
+  def tabulate(fill: Char, rightSep: String, rows: Iterable[(String, Doc)]): Doc =
+    if (rows.isEmpty) empty
     else {
-      val fills = kv.iterator.map(_._1.length).max
-      val leftD = Doc.text(leftSep)
+      val fills = rows.iterator.map(_._1.length).max
       val rightD = Doc.text(rightSep)
-      def keyToDoc(s: String): Doc = Doc.text(s) + leftD + Doc.char(fill).repeat(fills - s.length) + rightD
-      intercalate(line, kv.map { case (k, v) => keyToDoc(k) + v.aligned })
+      def keyToDoc(s: String): Doc = Doc.text(s) + Doc.char(fill).repeat(fills - s.length) + rightD
+      intercalate(line, rows.map { case (k, v) => keyToDoc(k) + v.aligned })
     }
 }

--- a/core/src/main/scala/com/github/johnynek/paiges/Doc.scala
+++ b/core/src/main/scala/com/github/johnynek/paiges/Doc.scala
@@ -840,9 +840,23 @@ object Doc {
     intercalate(line, ds)
 
   /**
+   * A simple table which is the same as:
+   * tabulate("", ' ', "", kv)
+   *
+   * or, no left or right separator and a space as the fill
+   */
+  def tabulate(kv: List[(String, Doc)]): Doc =
+    tabulate("", ' ', "", kv)
+
+  /**
    * build a table with the strings left aligned and
    * the Docs starting in the column after the longest string.
    * The Docs on the right are rendered aligned after the rightSep
+   *
+   * @param leftSep a string appended on the end of the key
+   * @param fill the character used to fill the columns to make the values aligned (i.e. ' ' or '.')
+   * @param rightSep a string append left to the left of the value. Intended for use with bullets on values
+   * @param kv a List of key, value pairs to put in a table.
    */
   def tabulate(leftSep: String, fill: Char, rightSep: String, kv: List[(String, Doc)]): Doc =
     if (kv.isEmpty) empty

--- a/core/src/main/scala/com/github/johnynek/paiges/Doc.scala
+++ b/core/src/main/scala/com/github/johnynek/paiges/Doc.scala
@@ -361,6 +361,13 @@ sealed abstract class Doc extends Product with Serializable {
   }
 
   /**
+   * semantic equivalence of Documents (not structural).
+   * a eqv b implies a compare b == 0
+   */
+  def eqv(that: Doc): Boolean =
+    (this eq that) || (compare(that) == 0)
+
+  /**
    * Compare two Docs by finding the first rendering where the strings
    * produced differ (if any).
    *
@@ -580,10 +587,14 @@ object Doc {
   def spaces(n: Int): Doc =
     if (n < 1) Empty
     else if (n <= maxSpaceTable) spaceArray(n - 1)
-    else Text(" " * n)
+    else {
+      // n = max * d + r
+      val d = n / maxSpaceTable
+      val r = n % maxSpaceTable
+      spaceArray(maxSpaceTable - 1) * d + spaces(r)
+    }
 
   val space: Doc = spaceArray(0)
-  val comma: Doc = Text(",")
   val empty: Doc = Empty
   /**
    * when flattened a line becomes a space
@@ -618,12 +629,20 @@ object Doc {
       def compare(x: Doc, y: Doc): Int = x compare y
     }
 
+  private[this] val charTable: Array[Doc] =
+    (32 to 126).map { i => Text(i.toChar.toString) }.toArray
+
   /**
    * Build a document from a single character.
    */
   def char(c: Char): Doc =
     if ((' ' <= c) && (c <= '~')) charTable(c.toInt - 32)
     else Text(new String(Array(c)))
+
+  /**
+   * a literal comma, equivalent to char(',')
+   */
+  val comma: Doc = char(',')
 
   /**
    * Convert a string to text.
@@ -655,9 +674,6 @@ object Doc {
     else if (str.indexOf('\n') < 0) Text(str)
     else parse(str.length - 1, str.length, Empty)
   }
-
-  private[this] val charTable: Array[Doc] =
-    (32 to 126).map { i => Text(i.toChar.toString) }.toArray
 
   /**
    * Convert an arbitrary value to a Doc, using `toString`.
@@ -823,4 +839,20 @@ object Doc {
    */
   def stack(ds: Iterable[Doc]): Doc =
     intercalate(line, ds)
+
+  /**
+   * build a table with the strings left aligned and
+   * the Docs starting in the column after the longest string.
+   * The Docs on the right are rendered aligned after the rightSep
+   */
+  def tabulate(leftSep: String, fill: Char, rightSep: String, kv: List[(String, Doc)]): Doc =
+    if (kv.isEmpty) empty
+    else {
+      val fills = kv.iterator.map(_._1.length).max
+      val width = leftSep.length + fills + rightSep.length
+      val leftD = Doc.text(leftSep)
+      val rightD = Doc.text(rightSep)
+      def keyToDoc(s: String): Doc = Doc.text(s) + leftD + Doc.char(fill).repeat(fills - s.length) + rightD
+      intercalate(line, kv.map { case (k, v) => keyToDoc(k) + v.aligned })
+    }
 }

--- a/core/src/test/scala/com/github/johnynek/paiges/Generators.scala
+++ b/core/src/test/scala/com/github/johnynek/paiges/Generators.scala
@@ -3,7 +3,7 @@ package org.typelevel.paiges
 import org.scalacheck.{Arbitrary, Cogen, Gen}
 
 object Generators {
-  import Doc.{ str, text }
+  import Doc.text
 
   val asciiString: Gen[String] =
     for {

--- a/core/src/test/scala/com/github/johnynek/paiges/PaigesTest.scala
+++ b/core/src/test/scala/com/github/johnynek/paiges/PaigesTest.scala
@@ -520,6 +520,6 @@ the spaces""")
                      |                                   callItem(y)
                      |                                   callItem(z)""".stripMargin
 
-    assert(Doc.tabulate("", ' ', " => ", caseMatch.map { case (s, d) => ("case " + s, d) }).render(20) == expected)
+    assert(Doc.tabulate(' ', " => ", caseMatch.map { case (s, d) => ("case " + s, d) }).render(20) == expected)
   }
 }

--- a/core/src/test/scala/com/github/johnynek/paiges/PaigesTest.scala
+++ b/core/src/test/scala/com/github/johnynek/paiges/PaigesTest.scala
@@ -76,6 +76,17 @@ the spaces""")
     }
   }
 
+  test("spaces(n) == text(\" \") * n == text(\" \" * n)") {
+    forAll(Gen.choose(-10, 1000)) { n =>
+      val sn = Doc.spaces(n)
+      val tn = Doc.text(" ") * n
+      val un = Doc.text(" " * n)
+
+      assert(sn eqv tn)
+      assert(tn eqv un)
+    }
+  }
+
   test("Doc.split(s, \" \", space).render(w) = s") {
     forAll { (s: String, w: Int) =>
       assert(Doc.split(s, " ".r, Doc.space).render(w) == s)
@@ -487,5 +498,21 @@ the spaces""")
       PropertyCheckConfiguration(minSuccessful = 5000)
 
     forAll(genDoc, genDoc, unary) { (a, b, f) => law(a, b, f) }
+  }
+
+  test("Doc.tabulate works in some example cases") {
+    val caseMatch = List(
+      ("Item1(x)", Doc.text("callItem(x)")),
+      ("ItemXandItemY(x, y)", Doc.text("callItem(x)") / Doc.text("callItem(y)")),
+      ("ItemXandItemYandZ(x, y, z)", Doc.text("callItem(x)") / Doc.text("callItem(y)") / Doc.text("callItem(z)")))
+
+    val expected = """case Item1(x)                   => callItem(x)
+                     |case ItemXandItemY(x, y)        => callItem(x)
+                     |                                   callItem(y)
+                     |case ItemXandItemYandZ(x, y, z) => callItem(x)
+                     |                                   callItem(y)
+                     |                                   callItem(z)""".stripMargin
+
+    assert(Doc.tabulate("", ' ', " => ", caseMatch.map { case (s, d) => ("case " + s, d) }).render(20) == expected)
   }
 }

--- a/core/src/test/scala/com/github/johnynek/paiges/PaigesTest.scala
+++ b/core/src/test/scala/com/github/johnynek/paiges/PaigesTest.scala
@@ -2,7 +2,7 @@ package org.typelevel.paiges
 
 import org.scalatest.FunSuite
 import org.scalatest.prop.PropertyChecks._
-import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.Gen
 import scala.collection.immutable.SortedSet
 
 class PaigesTest extends FunSuite {
@@ -60,6 +60,12 @@ the spaces""")
   test("(x = y) -> (x.## = y.##)") {
     forAll { (a: Doc, b: Doc) =>
       if ((a compare b) == 0) assert(a.## == b.##) else succeed
+    }
+  }
+
+  test("a eqv b iff a compare b == 0") {
+    forAll { (a: Doc, b: Doc) =>
+      assert((a eqv b) == (a.compare(b) == 0))
     }
   }
 
@@ -147,6 +153,7 @@ the spaces""")
         val allSame = (0 to maxR).forall { w =>
           a.render(w) == b.render(w)
         }
+        assert(allSame)
       }
       else succeed
     }


### PR DESCRIPTION
take a look at this @coltfred 

I *think* this will be enough for opt-parse-applicative. It models this method:

https://github.com/bmjames/scala-optparse-applicative/pull/13/files#diff-9af4bcd927b95bd619209389ada92c30R95

which I think is always called with a doc constructed from one or a few strings.

In the worst case, we could add `tabulate(cols: List[(Doc, Doc)], leftWidth: Int)` and render the left side into a String and take the same approach, which will work for more cases perhaps.