### PR TITLE
Add an option to skip spaces on bracketBy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ def mkCaseClass(name: String, fields: (String, String)*): Doc = {
   val types = fields.map { case (k, v) =>
     Doc.text(k) + Doc.char(':') + Doc.space + Doc.text(v)
   }
-  val body = Doc.intercalate(Doc.char(',') + Doc.lineOrSpace, types)
-  body.bracketBy(prefix, suffix)
+  val body = Doc.intercalate(Doc.char(',') + Doc.line, types)
+  body.bracketBy(prefix, suffix, spaces = false)
 }
 
 val c = mkCaseClass(
@@ -92,13 +92,7 @@ val c = mkCaseClass(
 c.render(80)
 // case class Dog(name: String, breed: String, height: Int, weight: Int)
 
-c.render(40)
-// case class Dog(
-//   name: String, breed: String,
-//   height: Int, weight: Int
-// )
-
-c.render(20)
+c.render(60)
 // case class Dog(
 //   name: String,
 //   breed: String,

--- a/core/src/main/scala/org/typelevel/paiges/Doc.scala
+++ b/core/src/main/scala/org/typelevel/paiges/Doc.scala
@@ -105,13 +105,19 @@ sealed abstract class Doc extends Product with Serializable {
     lineOrSpace(Doc.text(that))
 
   /**
-   * Bookend this Doc between the given Docs, separated by newlines
-   * and indentation (if space permits) or spaces otherwise.
+   * Bookend this Doc between the given Docs.
    *
-   * By default, the indentation is two spaces.
+   * If the documents (when flattened) all fit on one line, then
+   * newlines will be collapsed, spaces will be added if requested,
+   * and the document will render on one line.
+   *
+   * Otherwise, newlines will be used on either side of this document,
+   * and the requested level of indentation will be added as well.
    */
-  def bracketBy(left: Doc, right: Doc, indent: Int = 2): Doc =
-    Concat(left, Concat(Concat(Doc.line, this).nested(indent), Concat(Doc.line, right)).grouped)
+  def bracketBy(left: Doc, right: Doc, indent: Int = 2, spaces: Boolean = true): Doc = {
+    val line = if (spaces) Doc.line else Doc.lineBreak
+    Concat(left, Concat(Concat(line, this).nested(indent), Concat(line, right)).grouped)
+  }
 
   /**
    * Treat this Doc as a group that can be compressed.

--- a/core/src/test/scala/org/typelevel/paiges/PaigesTest.scala
+++ b/core/src/test/scala/org/typelevel/paiges/PaigesTest.scala
@@ -298,9 +298,14 @@ the spaces""")
   test("test json map example") {
     val kvs = (0 to 20).map { i => text("\"%s\": %s".format(s"key$i", i)) }
     val parts = Doc.fill(Doc.comma + Doc.lineOrSpace, kvs)
+
     val map = parts.bracketBy(Doc.text("{"), Doc.text("}"))
     assert(map.render(1000) == (0 to 20).map { i => "\"%s\": %s".format(s"key$i", i) }.mkString("{ ", ", ", " }"))
     assert(map.render(20) == (0 to 20).map { i => "\"%s\": %s".format(s"key$i", i) }.map("  " + _).mkString("{\n", ",\n", "\n}"))
+
+    val map2 = parts.bracketBy(Doc.text("{"), Doc.text("}"), spaces = false)
+    assert(map2.render(1000) == (0 to 20).map { i => "\"%s\": %s".format(s"key$i", i) }.mkString("{", ", ", "}"))
+    assert(map2.render(20) == (0 to 20).map { i => "\"%s\": %s".format(s"key$i", i) }.map("  " + _).mkString("{\n", ",\n", "\n}"))
   }
 
   test("Doc.repeat matches naive implementation") {


### PR DESCRIPTION
Previously, bracketBy always used spaces when fitting the document on
a single line. In the context of codegen this is often not what you
want. Now, there is an optional argument to control this behavior.

(The distinction has to do with whether to use Doc.line or
Doc.lineBreak in the actual implementation.)

For example:

```scala
val prefix = Doc.text("say(")
val body = Doc.text("something somewhat long")
val suffix = Doc.text(")")

body.bracketBy(prefix, suffix).render(80)
// say( something somewhat long )

body.bracketBy(prefix, suffix, spaces = false).render(80)
// say(something somewhat long)
```