### PR TITLE
Add 'cat' as analogy to 'stack' and 'spread'

### DIFF
--- a/core/src/main/scala/org/typelevel/paiges/Doc.scala
+++ b/core/src/main/scala/org/typelevel/paiges/Doc.scala
@@ -825,6 +825,14 @@ object Doc {
     else foldDocs(ds) { (a, b) => Concat(a, Concat(sep, b)) }
 
   /**
+   * Concatenate the given documents together.
+   *
+   * `cat(ds)` is equivalent to `ds.foldLeft(empty)(_ + _)`
+   */
+  def cat(ds: Iterable[Doc]): Doc =
+    intercalate(empty, ds)
+
+  /**
    * Concatenate the given documents together, delimited by spaces.
    */
   def spread(ds: Iterable[Doc]): Doc =

--- a/core/src/test/scala/org/typelevel/paiges/PaigesTest.scala
+++ b/core/src/test/scala/org/typelevel/paiges/PaigesTest.scala
@@ -469,4 +469,8 @@ the spaces""")
                      |epsilon: the ultimate case""".stripMargin
     assert(Doc.tabulate(pairs).render(40) == expected)
   }
+
+  test("cat") {
+    assert(Doc.cat(List("1", "2", "3") map Doc.text).render(80) == "123")
+  }
 }


### PR DESCRIPTION
While a small interface to this library is nice, I think a special case for
horizontal concatenation is as justified as those for space and newline.