### PR TITLE
Add '&' as shorter syntax for 'space'

### DIFF
--- a/core/src/main/scala/org/typelevel/paiges/Doc.scala
+++ b/core/src/main/scala/org/typelevel/paiges/Doc.scala
@@ -91,6 +91,28 @@ sealed abstract class Doc extends Product with Serializable {
     this.space(Doc.text(that))
 
   /**
+   * Append the given Doc to this one, separated by a space.
+   */
+  def &(that: Doc): Doc =
+    this space that
+
+  /**
+   * Append the given String to this Doc, separated by a space.
+   *
+   * The expression `str &: d` is equivalent to `Doc.text(str) & d`.
+   */
+  def &:(that: String): Doc =
+    Doc.text(that) space this
+
+  /**
+   * Append the given String to this Doc, separated by a space.
+   *
+   * The expression `d :& str` is equivalent to `d & Doc.text(str)`.
+   */
+  def :&(that: String): Doc =
+    this space Doc.text(that)
+
+  /**
    * Append the given Doc to this one, using a space (if there is
    * enough room), or a newline otherwise.
    */

--- a/core/src/test/scala/org/typelevel/paiges/PaigesTest.scala
+++ b/core/src/test/scala/org/typelevel/paiges/PaigesTest.scala
@@ -152,8 +152,11 @@ the spaces""")
 
   test("space works as expected") {
     forAll { (a: String, b: String) =>
-      assert((text(a) space b).render(0) ==
-        s"$a $b")
+      val res = s"$a $b"
+      assert((text(a) space b).render(0) == res)
+      assert((text(a) & text(b)).render(0) == res)
+      assert((text(a) :& b).render(0) == res)
+      assert((a &: text(b)).render(0) == res)
     }
   }
 


### PR DESCRIPTION
I think concatenation with space is just as common as with either empty or
newline.  This change adds more succinct syntax for this.  The analogous Haskell
library* also has syntax for this with '<+>'.  (It uses '<>' for our '+', and
'<$>' for our '/'.)

I don't care about the particular identifier, but I found having to type `foo space bar space baz` tiresome.

[*] https://hackage.haskell.org/package/wl-pprint-1.2/docs/Text-PrettyPrint-Leijen.html
