### PR TITLE
Add literal combinator to print strings verbatim.

### DIFF
--- a/core/src/main/scala/org/typelevel/paiges/Chunk.scala
+++ b/core/src/main/scala/org/typelevel/paiges/Chunk.scala
@@ -73,6 +73,9 @@ private[paiges] object Chunk {
       case (i, Doc.Nest(j, d)) :: z => loop(pos, ((i + j), d) :: z)
       case (_, Doc.Align(d)) :: z => loop(pos, (pos, d) :: z)
       case (i, Doc.Text(s)) :: z => ChunkStream.Item(s, pos + s.length, null, z, false)
+      case (_, l@Doc.Literal(s)) :: z =>
+        // isBreak=false because literal newlines have no indentation.
+        ChunkStream.Item(s, l.pos, null, z, false)
       case (i, Doc.Line(_)) :: z =>
         if (!trim) {
           ChunkStream.Item(null, i, null, z, true)

--- a/core/src/main/scala/org/typelevel/paiges/Doc.scala
+++ b/core/src/main/scala/org/typelevel/paiges/Doc.scala
@@ -754,10 +754,10 @@ object Doc {
   }
 
   /**
-   *  Convert a string into a doc verbatim, preserving newlines.
+   * Convert a string into a doc verbatim, preserving newlines.
    *
-   *  Newlines will not be flattened despite .grouped and don't get
-   *  indentation despite .nested.
+   * Newlines will not be flattened despite .grouped and don't get
+   * indentation despite .nested.
    */
   def literal(str: String): Doc = {
     if (str == "") Empty

--- a/core/src/main/scala/org/typelevel/paiges/Doc.scala
+++ b/core/src/main/scala/org/typelevel/paiges/Doc.scala
@@ -13,7 +13,7 @@ import scala.util.matching.Regex
  */
 sealed abstract class Doc extends Product with Serializable {
 
-  import Doc.{ Align, Empty, Text, Line, Nest, Concat, Union }
+  import Doc.{ Align, Empty, Text, Literal, Line, Nest, Concat, Union }
 
   /**
    * Append the given Doc to this one.
@@ -191,6 +191,8 @@ sealed abstract class Doc extends Product with Serializable {
         case Text(s) =>
           // shouldn't be empty by construction, but defensive
           s.isEmpty && loop(Empty, stack)
+        case Literal(s) =>
+          s.isEmpty && loop(Empty, stack)
         case Line(_) => false
         case Union(flattened, _) =>
           // flattening cannot change emptiness
@@ -271,6 +273,7 @@ sealed abstract class Doc extends Product with Serializable {
       case (i, Nest(j, d)) :: z => loop(pos, ((i + j), d) :: z)
       case (i, Align(d)) :: z => loop(pos, (pos, d) :: z)
       case (i, Text(s)) :: z => s #:: cheat(pos + s.length, z)
+      case (i, l@Literal(s)) :: z => s #:: cheat(l.pos, z)
       case (i, Line(_)) :: z => Chunk.lineToStr(i) #:: cheat(i, z)
       case (i, Union(a, _)) :: z =>
         /*
@@ -422,6 +425,8 @@ sealed abstract class Doc extends Product with Serializable {
                   loop(tail, s"Line($f)" +: suffix)
                 case Text(s) =>
                   loop(tail, "Text(" +: s +: ")" +: suffix)
+                case Literal(s) =>
+                  loop(tail, "Literal(" +: s.replace('\n', '¶') +: ")" +: suffix)
                 case Nest(i, d) =>
                   loop(Left(d) :: Right(", ") :: Right(i.toString) :: Right("Nest(") :: tail, ")" +: suffix)
                 case Align(d) =>
@@ -446,8 +451,9 @@ sealed abstract class Doc extends Product with Serializable {
    * Convert this Doc to a single-line representation.
    *
    * All newlines are replaced with spaces (and optional indentation
-   * is ignored). The resulting Doc will never render any newlines, no
-   * matter what width is used.
+   * is ignored). The resulting Doc will never render any newlines for text
+   * docs, no matter what width is used. Newlines inside literal docs
+   * continue to be rendered as newlines.
    */
   def flatten: Doc = {
 
@@ -464,7 +470,7 @@ sealed abstract class Doc extends Product with Serializable {
     @tailrec
     def loop(h: Doc, stack: List[Doc], front: List[Doc]): Doc =
       h match {
-        case Empty | Text(_) =>
+        case Empty | Text(_) | Literal(_) =>
           stack match {
             case Nil => finish(h, front)
             case x :: xs => loop(x, xs, h :: front)
@@ -505,7 +511,7 @@ sealed abstract class Doc extends Product with Serializable {
     @tailrec
     def loop(h: DB, stack: List[DB], front: List[DB]): DB =
       h._1 match {
-        case Empty | Text(_) =>
+        case Empty | Text(_) | Literal(_) =>
           stack match {
             case Nil => finish(h, front)
             case x :: xs => loop(x, xs, h :: front)
@@ -556,6 +562,7 @@ sealed abstract class Doc extends Product with Serializable {
       case (i, Nest(j, d)) :: z => loop(pos, ((i + j), d) :: z, max)
       case (i, Align(d)) :: z => loop(pos, (pos, d) :: z, max)
       case (i, Text(s)) :: z => loop(pos + s.length, z, max)
+      case (i, l@Literal(_)) :: z => loop(l.pos, z, max)
       case (i, Line(_)) :: z => loop(i, z, math.max(max, pos))
       case (i, Union(a, _)) :: z =>
         // we always go left, take the widest branch
@@ -585,6 +592,15 @@ object Doc {
    * The string must not be empty, and may not contain newlines.
    */
   private[paiges] case class Text(str: String) extends Doc
+
+  /**
+   * Same as Text except the string must contain a newline.
+   *
+   * Newlines don't flatten and don't get indentation.
+   */
+  private[paiges] case class Literal(str: String) extends Doc {
+    lazy val pos: Int = str.length - str.lastIndexOf('\n') - 1
+  }
 
   /**
    * Represents a concatenation of two documents.
@@ -735,6 +751,18 @@ object Doc {
     }
     else if (str.indexOf('\n') < 0) Text(str)
     else parse(str.length - 1, str.length, Empty)
+  }
+
+  /**
+   *  Convert a string into a doc verbatim, preserving newlines.
+   *
+   *  Newlines will not be flattened despite .grouped and don't get
+   *  indentation despite .nested.
+   */
+  def literal(str: String): Doc = {
+    if (str == "") Empty
+    else if (str.indexOf('\n') < 0) text(str)
+    else Literal(str)
   }
 
   /**

--- a/core/src/test/scala/org/typelevel/paiges/Generators.scala
+++ b/core/src/test/scala/org/typelevel/paiges/Generators.scala
@@ -22,6 +22,7 @@ object Generators {
     (1, Doc.lineOrSpace),
     (10, asciiString.map(text(_))),
     (10, generalString.map(text(_))),
+    (10, generalString.map(Doc.literal(_))),
     (3, asciiString.map(Doc.split(_))),
     (3, generalString.map(Doc.split(_))),
     (3, generalString.map(Doc.paragraph(_)))

--- a/core/src/test/scala/org/typelevel/paiges/LiteralTest.scala
+++ b/core/src/test/scala/org/typelevel/paiges/LiteralTest.scala
@@ -1,0 +1,42 @@
+package org.typelevel.paiges
+
+import org.scalatest.FunSuite
+import org.typelevel.paiges.Doc.{text, literal, line}
+
+class LiteralTest extends FunSuite {
+
+  test("ignore .nested") {
+    assert("\n" == literal("\n").nested(2).render(1))
+    assert("\n  " == text("\n").nested(2).render(1))
+  }
+
+  test("ignore .grouped") {
+    assert("\n" == literal("\n").grouped.render(1))
+    assert(" " == text("\n").grouped.render(1))
+  }
+
+  test("respect .render(width)") {
+    assert("\n " == (literal("\n") + line).grouped.render(1))
+    assert("\n \n" == (literal("\n ") + line).grouped.render(1))
+    assert("\n\n " == (literal("\n\n") + line).grouped.render(1))
+  }
+
+  test("respect .maxWidth") {
+    assert(literal("\n").grouped.maxWidth == 0)
+    assert(text("\n").grouped.maxWidth == 1)
+  }
+
+  test("respect .renderWideStream") {
+    assert("\n" == literal("\n").grouped.renderWideStream.mkString)
+    assert(" " == text("\n").grouped.renderWideStream.mkString)
+  }
+
+  test("respect .isEmpty") {
+    assert(literal("").isEmpty)
+  }
+
+  test("respect .representation") {
+    assert("Literal(a¶b)" == literal("a\nb").representation().render(10))
+  }
+
+}

--- a/core/src/test/scala/org/typelevel/paiges/PaigesTest.scala
+++ b/core/src/test/scala/org/typelevel/paiges/PaigesTest.scala
@@ -304,7 +304,7 @@ the spaces""")
   test("the left and right side of a union are the same after flattening") {
     import Doc._
     def okay(d: Doc): Boolean = d match {
-      case Empty | Text(_) | Line(_) => true
+      case Empty | Text(_) | Line(_) | Literal(_) => true
       case Concat(a, b) => okay(a) && okay(b)
       case Nest(j, d) => okay(d)
       case Align(d) => okay(d)
@@ -322,6 +322,7 @@ the spaces""")
       case Line(_) => (true, 0)
       case Empty => (false, 0)
       case Text(s) => (false, s.length)
+      case l@Literal(_) => (false, l.pos)
       case Nest(j, d) => nextLineLength(d) // nesteding only matters AFTER the next line
       case Align(d) => nextLineLength(d) // aligning only matters AFTER the next line
       case Concat(a, b) =>
@@ -334,7 +335,7 @@ the spaces""")
     }
 
     def okay(d: Doc): Boolean = d match {
-      case Empty | Text(_) | Line(_) => true
+      case Empty | Text(_) | Line(_) | Literal(_) => true
       case Nest(j, d) => okay(d)
       case Align(d) => okay(d)
       case Concat(a, b) => okay(a) && okay(b)


### PR DESCRIPTION
The motivation for the literal combinator is to be able to print
multiline string literals in for example source code. Scala multiline
string literals contain newlines that should never be flattened or get
indentation.