### PR TITLE
Add Failing trim-law

### DIFF
--- a/core/src/test/scala/org/typelevel/paiges/PaigesTest.scala
+++ b/core/src/test/scala/org/typelevel/paiges/PaigesTest.scala
@@ -157,6 +157,18 @@ the spaces""")
     }
   }
 
+  def slowRenderTrim(d: Doc, width: Int): String = {
+    val parts = d.render(100).split("\n", -1).toList
+    parts match {
+      case Nil => sys.error("unreachable")
+      case other =>
+        other.map { str =>
+          str.reverse.dropWhile(_ == ' ').reverse
+        }
+        .mkString("\n")
+    }
+  }
+
   test("dangling space 1") {
     val d = Doc.stack(
       List(
@@ -167,6 +179,7 @@ the spaces""")
     ).nested(2)
     val expected = "a\n  b\n"
     assert(d.renderTrim(100) == expected)
+    assert(d.renderTrim(100) == slowRenderTrim(d, 100))
     assert(d.renderStreamTrim(100).mkString == expected)
   }
 
@@ -182,7 +195,25 @@ the spaces""")
     ).nested(2)
     val expected = "\n  a\n\n\n  b"
     assert(d.renderTrim(100) == expected)
+    assert(d.renderTrim(100) == slowRenderTrim(d, 100))
     assert(d.renderStreamTrim(100).mkString == expected)
+  }
+
+  test("renderStreamTrim and renderTrim are consistent") {
+    forAll { (d: Doc, width0: Int) =>
+      val width = width0 & 0xFFF
+      assert(d.renderStreamTrim(width).mkString == d.renderTrim(width),
+        s"input=${d.representation().render(100)}")
+    }
+  }
+
+  test("trim-law: renderTrim is what we expect") {
+    forAll { (d: Doc) =>
+      val trim = d.renderTrim(100)
+      val slowTrim = slowRenderTrim(d, 100)
+
+      assert(trim == slowTrim, s"input=${d.representation().render(100)}")
+    }
   }
 
   test("(a /: b)  works as expected") {

--- a/core/src/test/scala/org/typelevel/paiges/PaigesTest.scala
+++ b/core/src/test/scala/org/typelevel/paiges/PaigesTest.scala
@@ -158,7 +158,7 @@ the spaces""")
   }
 
   def slowRenderTrim(d: Doc, width: Int): String = {
-    val parts = d.render(100).split("\n", -1).toList
+    val parts = d.render(width).split("\n", -1).toList
     parts match {
       case Nil => sys.error("unreachable")
       case other =>


### PR DESCRIPTION
I don't know exactly what we say the contract of trim is, but for both ideas I had it fails this law.

Do we strip all the trailing whitespace, or do we only strip from all but the last line (our current tests suggest that is not true).

The test fails now.

This is to address #78 

cc @seanmcl 