### PR TITLE
Add test suite for desired behavior of non-flattenable lines

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -107,7 +107,7 @@ def previousArtifact(version: String, proj: String) = {
 }
 
 lazy val commonJvmSettings = Seq(
-  testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDF"))
+  testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oD"))
 
 lazy val commonJsSettings = Seq(
   scalaJSStage in Global := FastOptStage,

--- a/core/src/test/scala/org/typelevel/paiges/LineTest.scala
+++ b/core/src/test/scala/org/typelevel/paiges/LineTest.scala
@@ -1,0 +1,47 @@
+package org.typelevel.paiges
+
+import org.scalatest.FunSuite
+import org.typelevel.paiges.Doc._
+
+class LineTest extends FunSuite {
+
+  // same as `line` except `lineNoFlat.flatBoolean` returns (this, changed=false).
+  // Required for line breaks that are treated as semicolons: { a\nb }
+  val lineNoFlat = line
+
+  // same as `lineNoFlat` except it does not respect nesting.
+  // Required to print verbatim line breaks such as in multiline strings: """\n""".
+  val lineNoFlatNoNesting = line
+
+  test("lineNoFlat cancels grouping") {
+    assert("\n\n" == (line + lineNoFlat).grouped.render(100))
+  }
+
+  test("lineNoFlat preserves nesting") {
+    assert("\n  \n  " == (line + lineNoFlat).grouped.nested(2).render(100))
+  }
+
+  test("lineNoFlatNoIndent cancels grouping") {
+    assert("\n\n" == (line + lineNoFlatNoNesting).grouped.render(100))
+
+  }
+
+  test("lineNoFlatNoIndent ignores nesting") {
+    assert(
+      "\n  \n" == (line + lineNoFlatNoNesting).grouped.nested(2).render(100))
+  }
+
+  test("it's possible to use print multiline strings and use .grouped") {
+    val tripleQuote = text("'''")
+    val multilineString = tripleQuote + lineNoFlatNoNesting + tripleQuote
+    val doc = text("foo") + multilineString.tightBracketBy(text("("), text(")"))
+    assert(
+      doc.grouped.render(100) ==
+        """foo(
+          |  '''
+          |'''
+          |)""".stripMargin
+    )
+  }
+
+}


### PR DESCRIPTION
A few test cases to demonstrate the desired behavior to fix #76. The test suite currently fails with
```
LineTest:
- lineNoFlat cancels grouping *** FAILED *** (26 milliseconds)
  "[

  ]" did not equal "[  ]" (LineTest.scala:17)
- lineNoFlat preserves nesting *** FAILED *** (1 millisecond)
  "[

  ]  " did not equal "[]  " (LineTest.scala:21)
- lineNoFlatNoIndent cancels grouping *** FAILED *** (1 millisecond)
  "[

  ]" did not equal "[  ]" (LineTest.scala:25)
- lineNoFlatNoIndent ignores nesting *** FAILED *** (0 milliseconds)
  "[

  ]" did not equal "[  ]" (LineTest.scala:30)
- it's possible to use print multiline strings and use .grouped *** FAILED *** (1 millisecond)
  "foo([''' '''])" did not equal "foo([
    '''
  '''
  ])" (LineTest.scala:38)
```