### PR TITLE
DO NOT MERGE: Create lineNoFlat(NoIndent) combinators.

### DIFF
--- a/benchmark/src/main/scala/PaigesBenchmark.scala
+++ b/benchmark/src/main/scala/PaigesBenchmark.scala
@@ -41,10 +41,10 @@ class PaigesBenchmark {
 
   @Benchmark
   def fill0(): String =
-    Doc.fill(Doc.text(","), strs.map(Doc.text)).render(0)
+    Doc.fill(Doc.text(","), strs.map(Doc.text)).get.render(0)
 
   @Benchmark
   def fill100(): String =
-    Doc.fill(Doc.text(","), strs.map(Doc.text)).render(100)
+    Doc.fill(Doc.text(","), strs.map(Doc.text)).get.render(100)
 
 }

--- a/core/src/main/scala/org/typelevel/paiges/Document.scala
+++ b/core/src/main/scala/org/typelevel/paiges/Document.scala
@@ -33,7 +33,7 @@ object Document {
 
   def documentIterable[A](name: String)(implicit ev: Document[A]): Document[Iterable[A]] =
     Document.instance { xs =>
-      val body = Doc.fill(Doc.comma + Doc.line, xs.map(ev.document))
+      val body = Doc.fill(Doc.comma + Doc.line, xs.map(ev.document)).get /* ??? */
       body.tightBracketBy(Doc.text(name) :+ "(", Doc.char(')'))
     }
 

--- a/core/src/test/scala/org/typelevel/paiges/Generators.scala
+++ b/core/src/test/scala/org/typelevel/paiges/Generators.scala
@@ -18,6 +18,8 @@ object Generators {
     (1, Doc.empty),
     (1, Doc.space),
     (1, Doc.line),
+//    (1, Doc.line2),
+//    (1, Doc.line3),
     (1, Doc.lineBreak),
     (1, Doc.lineOrSpace),
     (10, asciiString.map(text(_))),
@@ -43,7 +45,7 @@ object Generators {
   val folds: Gen[(List[Doc] => Doc)] =
     Gen.oneOf(
     doc0Gen.map { sep =>
-      { ds: List[Doc] => Doc.fill(sep, ds.take(8)) }
+      { ds: List[Doc] => Doc.fill(sep, ds.take(8)).get }
     },
     Gen.const({ ds: List[Doc] => Doc.spread(ds) }),
     Gen.const({ ds: List[Doc] => Doc.stack(ds) }))

--- a/core/src/test/scala/org/typelevel/paiges/JsonTest.scala
+++ b/core/src/test/scala/org/typelevel/paiges/JsonTest.scala
@@ -46,7 +46,7 @@ object Json {
       val kvs = toMap.map { case (s, j) =>
         JString(s).toDoc + text(":") + ((Doc.lineOrSpace + j.toDoc).nested(2))
       }
-      val parts = Doc.fill(Doc.comma, kvs)
+      val parts = Doc.fill(Doc.comma, kvs).get
       parts.bracketBy(text("{"), text("}"))
     }
   }

--- a/core/src/test/scala/org/typelevel/paiges/LineTests.scala
+++ b/core/src/test/scala/org/typelevel/paiges/LineTests.scala
@@ -1,0 +1,31 @@
+package org.typelevel.paiges
+
+import org.scalatest.FunSuite
+import Doc._
+
+class LineTests extends FunSuite {
+  test("line2 cancels grouping") {
+    assert("\n\n" == (line + lineNoFlat).grouped.render(10))
+  }
+  test("line2 preserves nesting") {
+    assert("\n  \n  " == (line + lineNoFlat).grouped.nested(2).render(10))
+  }
+  test("line3 cancels grouping") {
+    assert("\n\n" == (line + lineNoFlatNoIndent).grouped.render(10))
+
+    val quote = text("\"\"\"")
+    val string = quote + lineNoFlatNoIndent + quote
+    val doc = text("foo") + string.tightBracketBy(text("("), text(")"))
+    assert(
+      doc.grouped.render(100) ==
+        """foo(
+        |  '''
+        |'''
+        |)""".stripMargin.replace('\'', '"')
+    )
+  }
+  test("line3 ignores nesting") {
+    assert("\n  \n" == (line + lineNoFlatNoIndent).grouped.nested(2).render(10))
+  }
+
+}

--- a/core/src/test/scala/org/typelevel/paiges/PaigesScalacheckTest.scala
+++ b/core/src/test/scala/org/typelevel/paiges/PaigesScalacheckTest.scala
@@ -173,7 +173,7 @@ class PaigesScalacheckTest extends FunSuite {
      * flatten(c) + b.grouped == (flatten(c) + b).grouped
      */
     forAll { (b: Doc, c: Doc) =>
-      val flatC = c.flatten
+      val flatC = c.flatten.get
       val left = (b.grouped + flatC)
       val right = (b + flatC).grouped
       assert(left === right)
@@ -184,18 +184,18 @@ class PaigesScalacheckTest extends FunSuite {
   }
   test("flatten(group(a)) == flatten(a)") {
     forAll { (a: Doc) =>
-      assert(a.grouped.flatten === a.flatten)
+      assert(a.grouped.flatten.get === a.flatten.get)
     }
   }
   test("a.flatten == a.flatten.flatten") {
     forAll { (a: Doc) =>
-      val aflat = a.flatten
-      assert(aflat === aflat.flatten)
+      val aflat = a.flatten.get
+      assert(aflat === aflat.flatten.get)
     }
   }
   test("a.flatten == a.flattenOption.getOrElse(a)") {
     forAll { (a: Doc) =>
-      assert(a.flatten === a.flattenOption.getOrElse(a))
+      assert(a.flatten.get === a.flattenOption.getOrElse(a))
     }
   }
 
@@ -207,7 +207,7 @@ class PaigesScalacheckTest extends FunSuite {
       case Nest(j, d) => okay(d)
       case Align(d) => okay(d)
       case u@Union(a, _) =>
-        (a.flatten === u.bDoc.flatten) && okay(a) && okay(u.bDoc)
+        (a.flatten.get === u.bDoc.flatten.get) && okay(a) && okay(u.bDoc)
     }
 
     forAll { (a: Doc) => assert(okay(a)) }

--- a/core/src/test/scala/org/typelevel/paiges/PaigesTest.scala
+++ b/core/src/test/scala/org/typelevel/paiges/PaigesTest.scala
@@ -2,6 +2,8 @@ package org.typelevel.paiges
 
 import org.scalatest.FunSuite
 import scala.util.Random
+import org.scalatest.prop.PropertyChecks._
+import Generators._
 
 object PaigesTest {
   implicit val docEquiv: Equiv[Doc] =
@@ -130,7 +132,7 @@ the spaces""")
      *   (a * n * (b * s * c) | (b * n * c))
      */
     val first = Doc.paragraph("a b c")
-    val second = Doc.fill(Doc.lineOrSpace, List("a", "b", "c").map(Doc.text))
+    val second = Doc.fill(Doc.lineOrSpace, List("a", "b", "c").map(Doc.text)).get
     /*
      * I think this fails perhaps because of the way fill constructs
      * Unions. It violates a stronger invariant that Union(a, b)
@@ -162,7 +164,7 @@ the spaces""")
 
   test("test json map example") {
     val kvs = (0 to 20).map { i => text("\"%s\": %s".format(s"key$i", i)) }
-    val parts = Doc.fill(Doc.comma + Doc.lineOrSpace, kvs)
+    val parts = Doc.fill(Doc.comma + Doc.lineOrSpace, kvs).get
 
     val map = parts.bracketBy(Doc.text("{"), Doc.text("}"))
     assert(map.render(1000) == (0 to 20).map { i => "\"%s\": %s".format(s"key$i", i) }.mkString("{ ", ", ", " }"))
@@ -206,7 +208,7 @@ the spaces""")
   test("fill example") {
     import Doc.{ comma, text, fill }
     val ds = text("1") :: text("2") :: text("3") :: Nil
-    val doc = fill(comma + Doc.line, ds)
+    val doc = fill(comma + Doc.line, ds).get
 
     assert(doc.render(0) == "1,\n2,\n3")
     assert(doc.render(6) == "1, 2,\n3")


### PR DESCRIPTION
This is just @olafurpg's change 114ec05b4a3099906c9159ccd1357f3b772b4f1d rebased to master

These combinators are necessary to model
- lines that should never flatten, but respect indentation. For
example, a line separating two statements or a newline following
a single-line `// comment` comment.

```scala
{
  stat1 // newline here should never flatten
  stat2
}
```
- lines that should never flatten AND should not get indentation.
For example, newlines inside multiline string literals.

```scala
{
  foo("""
""") // newline should not indent or flatten.
}
```