### PR TITLE
Modify test with undefined behavior

### DIFF
--- a/core/src/test/scala/org/typelevel/paiges/PaigesTest.scala
+++ b/core/src/test/scala/org/typelevel/paiges/PaigesTest.scala
@@ -34,7 +34,7 @@ object PaigesTest {
 }
 
 class PaigesTest extends FunSuite {
-  import Doc.text
+  import Doc.{line, text}
   import PaigesTest._
 
   test("basic test") {
@@ -42,7 +42,7 @@ class PaigesTest extends FunSuite {
   }
 
   test("nested test") {
-    assert((text("yo") + (text("yo\nho\nho").nested(2))).render(100) ==
+    assert((text("yo") + (text("yo") + line + text("ho") + line + text("ho")).nested(2)).render(100) ==
 """yoyo
   ho
   ho""")


### PR DESCRIPTION
We explicitly state that Text fields can't have newlines.
This change fixes a test that formerly had explicit newlines.