### PR TITLE
Revert "Modify tests with undefined behavior"

### DIFF
--- a/core/src/test/scala/org/typelevel/paiges/PaigesTest.scala
+++ b/core/src/test/scala/org/typelevel/paiges/PaigesTest.scala
@@ -34,7 +34,7 @@ object PaigesTest {
 }
 
 class PaigesTest extends FunSuite {
-  import Doc.{line, text}
+  import Doc.text
   import PaigesTest._
 
   test("basic test") {
@@ -42,7 +42,7 @@ class PaigesTest extends FunSuite {
   }
 
   test("nested test") {
-    assert((text("yo") + (text("yo") + line + text("ho") + line + text("ho")).nested(2)).render(100) ==
+    assert((text("yo") + (text("yo\nho\nho").nested(2))).render(100) ==
 """yoyo
   ho
   ho""")


### PR DESCRIPTION
This reverts commit 699860f30710f5a437972dce084e9294cae5eae4.
I removed the test because I thought `text` was not allowed
to have \n characters.  It's the constructor, not the
function, to which that applies.