### PR TITLE
Add comment about Union invariant

### DIFF
--- a/core/src/main/scala/org/typelevel/paiges/Doc.scala
+++ b/core/src/main/scala/org/typelevel/paiges/Doc.scala
@@ -584,7 +584,9 @@ object Doc {
    *
    * Additionally, the left side (a) MUST be right associated with
    * any Concat nodes to maintain efficiency in rendering. This
-   * is currently done by flatten/flattenOption
+   * is currently done by flatten/flattenOption.
+   *
+   * Finally, we have the invariant a != b.
    */
   private[paiges] case class Union(a: Doc, b: Doc) extends Doc
 


### PR DESCRIPTION
This invariant makes sense, and the author of the code
clearly had it in mind since they added code comments
like "Note that first != second".