### PR TITLE
Don't allow misuse of LazyDoc

### DIFF
--- a/core/src/main/scala/org/typelevel/paiges/Doc.scala
+++ b/core/src/main/scala/org/typelevel/paiges/Doc.scala
@@ -567,7 +567,10 @@ object Doc {
    */
   private[paiges] case class Align(doc: Doc) extends Doc
 
-  private[paiges] case class LazyDoc(generate: () => Doc) extends Doc {
+  /**
+   * Invariant: generate is referentially transparent
+   */
+  private[paiges] case class LazyDoc(private val generate: () => Doc) extends Doc {
     lazy val evaluated: Doc = generate()
   }
 


### PR DESCRIPTION
We assume the only use of (the referentially transparent) `generate`
should be cached via `evaluated`.  This obviates mistakes where
we throw away work by calling `generate` directly.