### PR TITLE
Really hide the LazyDoc argument

### DIFF
--- a/core/src/main/scala/org/typelevel/paiges/Chunk.scala
+++ b/core/src/main/scala/org/typelevel/paiges/Chunk.scala
@@ -109,7 +109,7 @@ private[paiges] object Chunk {
       case (_, Doc.Align(d)) :: z => loop(pos, (pos, d) :: z)
       case (i, Doc.Text(s)) :: z => ChunkStream.Item(s, pos + s.length, z, false)
       case (i, Doc.Line(_)) :: z => ChunkStream.Item(null, i, z, true)
-      case (i, l@Doc.LazyDoc(_)) :: z => loop(pos, (i, l.evaluated) :: z)
+      case (i, Doc.LazyDoc(d)) :: z => loop(pos, (i, d.evaluated) :: z)
       case (i, Doc.Union(x, y)) :: z =>
         /*
          * If we can fit the next line from x, we take it.

--- a/core/src/test/scala/org/typelevel/paiges/PaigesScalacheckTest.scala
+++ b/core/src/test/scala/org/typelevel/paiges/PaigesScalacheckTest.scala
@@ -206,7 +206,7 @@ class PaigesScalacheckTest extends FunSuite {
       case Concat(a, b) => okay(a) && okay(b)
       case Nest(j, d) => okay(d)
       case Align(d) => okay(d)
-      case l@LazyDoc(_) => okay(l.evaluated)
+      case LazyDoc(d) => okay(d.evaluated)
       case Union(a, b) =>
         (a.flatten === b.flatten) && okay(a) && okay(b)
     }
@@ -229,7 +229,7 @@ class PaigesScalacheckTest extends FunSuite {
           val (d2, l2) = nextLineLength(b)
           (d2, l2 + l)
         } else r1
-      case l@LazyDoc(_) => nextLineLength(l.evaluated)
+      case LazyDoc(d) => nextLineLength(d.evaluated)
       case Union(a, _) => nextLineLength(a) // assume the property is true
     }
 
@@ -238,7 +238,7 @@ class PaigesScalacheckTest extends FunSuite {
       case Nest(j, d) => okay(d)
       case Align(d) => okay(d)
       case Concat(a, b) => okay(a) && okay(b)
-      case l@LazyDoc(_) => okay(l.evaluated)
+      case LazyDoc(d) => okay(d.evaluated)
       case Union(a, b) =>
         nextLineLength(a)._2 >= nextLineLength(b)._2
     }


### PR DESCRIPTION
I'm not sure about this change, but it does eliminate
a potential programming mistake.  Typecasing is known
to be an effect in general, but here it seems harmless.

WDYT?