### PR TITLE
Replace renderWideStream with renderCompactStream

### DIFF
--- a/core/src/test/scala/org/typelevel/paiges/PaigesScalacheckTest.scala
+++ b/core/src/test/scala/org/typelevel/paiges/PaigesScalacheckTest.scala
@@ -294,12 +294,6 @@ class PaigesScalacheckTest extends FunSuite {
       assert(d.render(w) == d.renderStream(w).mkString)
     }
   }
-  test("renderWide == render(maxWidth)") {
-    forAll { (d: Doc) =>
-      val max = d.maxWidth
-      assert(d.renderWideStream.mkString == d.render(max))
-    }
-  }
 
   test("character concat works") {
     forAll { (c1: Char, c2: Char) =>

--- a/core/src/test/scala/org/typelevel/paiges/PaigesTest.scala
+++ b/core/src/test/scala/org/typelevel/paiges/PaigesTest.scala
@@ -177,9 +177,9 @@ the spaces""")
     assert(Doc.intercalate(Doc.lineOrSpace, (1 to 100000).map(Doc.str)).maxWidth >= 0)
   }
 
-  test("renderWide is stack safe") {
+  test("renderCompactStream is stack safe") {
     val nums = (1 to 100000)
-    assert(Doc.intercalate(Doc.lineOrSpace, nums.map(Doc.str)).renderWideStream.mkString == nums.mkString(" "))
+    assert(Doc.intercalate(Doc.space, nums.map(Doc.str)).renderCompactStream.mkString == nums.mkString(" "))
   }
 
   test("lineBreak works as expected") {


### PR DESCRIPTION
In the presence of hard line breaks, renderWideStream seems
hard to justify as a stack-safe procedure; if flattening
fails, it's not satisfying to consider it as a wide stream,
as the document is just rendered as is. It may be possible
to give it some concrete semantics, e.g. hard lines ignore
indent, but otherwise try to maximally lay out lines, but
it's hardly canonical in the same way it was when there were
no hard line breaks.

It seems used mainly to quickly implement hashCode, so this
change simply makes a quick compact document for that purpose.