### PR TITLE
Simplify `fill`

### DIFF
--- a/core/src/main/scala/org/typelevel/paiges/Document.scala
+++ b/core/src/main/scala/org/typelevel/paiges/Document.scala
@@ -33,7 +33,7 @@ object Document {
 
   def documentIterable[A](name: String)(implicit ev: Document[A]): Document[Iterable[A]] =
     Document.instance { xs =>
-      val body = Doc.fill(Doc.comma + Doc.line, xs.map(ev.document))
+      val body = Doc.fill(Doc.comma + Doc.lineOrSpace, xs.map(ev.document))
       body.tightBracketBy(Doc.text(name) :+ "(", Doc.char(')'))
     }
 

--- a/core/src/test/scala/org/typelevel/paiges/PaigesTest.scala
+++ b/core/src/test/scala/org/typelevel/paiges/PaigesTest.scala
@@ -150,7 +150,7 @@ the spaces""")
 
   test("test json array example") {
     val items = (0 to 20).map(Doc.str(_))
-    val parts = Doc.fill(Doc.comma + Doc.line, items)
+    val parts = Doc.fill(Doc.comma + Doc.lineOrSpace, items)
     val ary = "[" +: ((parts :+ "]").aligned)
     assert(ary.renderWideStream.mkString == (0 to 20).mkString("[", ", ", "]"))
     val expect = """[0, 1, 2, 3, 4, 5,
@@ -206,7 +206,7 @@ the spaces""")
   test("fill example") {
     import Doc.{ comma, text, fill }
     val ds = text("1") :: text("2") :: text("3") :: Nil
-    val doc = fill(comma + Doc.line, ds)
+    val doc = fill(comma + Doc.lineOrSpace, ds)
 
     assert(doc.render(0) == "1,\n2,\n3")
     assert(doc.render(6) == "1, 2,\n3")


### PR DESCRIPTION
This change makes our library closer to the Haskell cousin.  The change largely either stayed the same or improved the performance of the benchmarks.

===========
Before:

```
[info] Benchmark                       (size)   Mode  Cnt      Score      Error   Units
[info] PaigesBenchmark.docConcat            1  thrpt    5   6021.181 ± 2163.601  ops/ms
[info] PaigesBenchmark.docConcat           10  thrpt    5   1419.530 ±  185.223  ops/ms
[info] PaigesBenchmark.docConcat          100  thrpt    5    170.603 ±    3.664  ops/ms
[info] PaigesBenchmark.docConcat         1000  thrpt    5     16.290 ±    0.150  ops/ms
[info] PaigesBenchmark.docConcat        10000  thrpt    5      1.494 ±    0.099  ops/ms
[info] PaigesBenchmark.docConcatComma       1  thrpt    5   4930.306 ±  100.957  ops/ms
[info] PaigesBenchmark.docConcatComma      10  thrpt    5    833.244 ±   10.802  ops/ms
[info] PaigesBenchmark.docConcatComma     100  thrpt    5     93.753 ±    5.555  ops/ms
[info] PaigesBenchmark.docConcatComma    1000  thrpt    5      8.907 ±    0.478  ops/ms
[info] PaigesBenchmark.docConcatComma   10000  thrpt    5      0.807 ±    0.038  ops/ms
[info] PaigesBenchmark.fill0                1  thrpt    5   2835.954 ±   78.807  ops/ms
[info] PaigesBenchmark.fill0               10  thrpt    5    602.653 ±   24.589  ops/ms
[info] PaigesBenchmark.fill0              100  thrpt    5     70.979 ±    4.953  ops/ms
[info] PaigesBenchmark.fill0             1000  thrpt    5      6.931 ±    0.738  ops/ms
[info] PaigesBenchmark.fill0            10000  thrpt    5      0.653 ±    0.007  ops/ms
[info] PaigesBenchmark.fill100              1  thrpt    5   2846.016 ±   53.495  ops/ms
[info] PaigesBenchmark.fill100             10  thrpt    5    602.853 ±   32.603  ops/ms
[info] PaigesBenchmark.fill100            100  thrpt    5     70.970 ±    1.499  ops/ms
[info] PaigesBenchmark.fill100           1000  thrpt    5      6.996 ±    0.287  ops/ms
[info] PaigesBenchmark.fill100          10000  thrpt    5      0.639 ±    0.024  ops/ms
[info] PaigesBenchmark.intercalate          1  thrpt    5   4468.539 ±  158.518  ops/ms
[info] PaigesBenchmark.intercalate         10  thrpt    5    793.673 ±   13.572  ops/ms
[info] PaigesBenchmark.intercalate        100  thrpt    5     92.712 ±    1.311  ops/ms
[info] PaigesBenchmark.intercalate       1000  thrpt    5      8.693 ±    0.180  ops/ms
[info] PaigesBenchmark.intercalate      10000  thrpt    5      0.835 ±    0.026  ops/ms
[info] PaigesBenchmark.mkstring             1  thrpt    5  15622.275 ±  418.848  ops/ms
[info] PaigesBenchmark.mkstring            10  thrpt    5   4898.484 ±  163.182  ops/ms
[info] PaigesBenchmark.mkstring           100  thrpt    5    545.595 ±   14.278  ops/ms
[info] PaigesBenchmark.mkstring          1000  thrpt    5     49.358 ±    1.521  ops/ms
[info] PaigesBenchmark.mkstring         10000  thrpt    5      4.749 ±    0.079  ops/ms
[info] PaigesBenchmark.mkstringComma        1  thrpt    5  15775.865 ±  172.239  ops/ms
[info] PaigesBenchmark.mkstringComma       10  thrpt    5   3299.303 ±   69.193  ops/ms
[info] PaigesBenchmark.mkstringComma      100  thrpt    5    384.953 ±   50.693  ops/ms
[info] PaigesBenchmark.mkstringComma     1000  thrpt    5     38.209 ±    0.670  ops/ms
[info] PaigesBenchmark.mkstringComma    10000  thrpt    5      4.099 ±    0.114  ops/ms
```

After
=======
```
[info] Benchmark                       (size)   Mode  Cnt      Score      Error   Units
[info] PaigesBenchmark.docConcat            1  thrpt    5   6370.159 ±  694.069  ops/ms
[info] PaigesBenchmark.docConcat           10  thrpt    5   1488.719 ±  181.094  ops/ms
[info] PaigesBenchmark.docConcat          100  thrpt    5    171.754 ±   12.649  ops/ms
[info] PaigesBenchmark.docConcat         1000  thrpt    5     15.974 ±    4.037  ops/ms
[info] PaigesBenchmark.docConcat        10000  thrpt    5      1.570 ±    0.023  ops/ms
[info] PaigesBenchmark.docConcatComma       1  thrpt    5   4988.371 ±  550.573  ops/ms
[info] PaigesBenchmark.docConcatComma      10  thrpt    5    847.618 ±   42.766  ops/ms
[info] PaigesBenchmark.docConcatComma     100  thrpt    5     91.833 ±    8.005  ops/ms
[info] PaigesBenchmark.docConcatComma    1000  thrpt    5      8.821 ±    0.540  ops/ms
[info] PaigesBenchmark.docConcatComma   10000  thrpt    5      0.779 ±    0.186  ops/ms
[info] PaigesBenchmark.fill0                1  thrpt    5   3192.448 ±   67.078  ops/ms
[info] PaigesBenchmark.fill0               10  thrpt    5    699.142 ±   45.233  ops/ms
[info] PaigesBenchmark.fill0              100  thrpt    5     84.763 ±   12.665  ops/ms
[info] PaigesBenchmark.fill0             1000  thrpt    5      4.767 ±    8.248  ops/ms
[info] PaigesBenchmark.fill0            10000  thrpt    5      0.769 ±    0.018  ops/ms
[info] PaigesBenchmark.fill100              1  thrpt    5   3086.837 ±  218.348  ops/ms
[info] PaigesBenchmark.fill100             10  thrpt    5    685.441 ±   26.430  ops/ms
[info] PaigesBenchmark.fill100            100  thrpt    5     85.320 ±    5.387  ops/ms
[info] PaigesBenchmark.fill100           1000  thrpt    5      8.475 ±    0.222  ops/ms
[info] PaigesBenchmark.fill100          10000  thrpt    5      0.792 ±    0.021  ops/ms
[info] PaigesBenchmark.intercalate          1  thrpt    5   4538.417 ±  288.931  ops/ms
[info] PaigesBenchmark.intercalate         10  thrpt    5    775.586 ±  107.214  ops/ms
[info] PaigesBenchmark.intercalate        100  thrpt    5     94.182 ±    1.733  ops/ms
[info] PaigesBenchmark.intercalate       1000  thrpt    5      8.588 ±    0.781  ops/ms
[info] PaigesBenchmark.intercalate      10000  thrpt    5      0.813 ±    0.135  ops/ms
[info] PaigesBenchmark.mkstring             1  thrpt    5  15082.939 ±  676.266  ops/ms
[info] PaigesBenchmark.mkstring            10  thrpt    5   4106.645 ± 1047.273  ops/ms
[info] PaigesBenchmark.mkstring           100  thrpt    5    539.884 ±   17.778  ops/ms
[info] PaigesBenchmark.mkstring          1000  thrpt    5     50.778 ±    1.268  ops/ms
[info] PaigesBenchmark.mkstring         10000  thrpt    5      5.139 ±    0.211  ops/ms
[info] PaigesBenchmark.mkstringComma        1  thrpt    5  11901.617 ±  170.130  ops/ms
[info] PaigesBenchmark.mkstringComma       10  thrpt    5   3392.139 ±  101.032  ops/ms
[info] PaigesBenchmark.mkstringComma      100  thrpt    5    396.867 ±   11.636  ops/ms
[info] PaigesBenchmark.mkstringComma     1000  thrpt    5     38.993 ±    0.804  ops/ms
[info] PaigesBenchmark.mkstringComma    10000  thrpt    5      4.158 ±    0.378  ops/ms
```

The last one is a little weird.  My laptop was about to run out of power on the plane which perhaps explains it.  It's not testing the library anyway, so I figured others could at least run the benchmarks themselves.

With this change the FlatAlt change passes all tests.  