### PR TITLE
Add more `Union` invariant tests and clarify comments

### DIFF
--- a/core/src/main/scala/org/typelevel/paiges/Doc.scala
+++ b/core/src/main/scala/org/typelevel/paiges/Doc.scala
@@ -576,19 +576,16 @@ object Doc {
   /**
    * Represents an optimistic rendering (on the left) as well as a
    * fallback rendering (on the right) if the first line of the left
-   * is too long.
+   * is too long.  In `Union(a, b)`, we have the invariants:
    *
-   * There is an additional invariant on Union: `flatten(a) == flatten(b)`.
+   * - `a.flatten == b.flatten`
+   * - `a != b` (otherwise the Union would be redundant)
+   * - `a` is right-associated with respect to `Concat` nodes to maintain efficiency in rendering.
+   * - The first line of `a` is longer than the first line of `b` at all widths.
    *
-   * By construction all `Union` nodes have this property; to preserve
+   * By construction all `Union` nodes have these properties; to preserve
    * this we don't expose the `Union` constructor directly, but only
-   * the `.grouped` method on Doc.
-   *
-   * Additionally, the left side (a) MUST be right associated with
-   * any Concat nodes to maintain efficiency in rendering. This
-   * is currently done by flatten/flattenOption.
-   *
-   * Finally, we have the invariant a != b.
+   * the `grouped` and `fill` methods.
    */
   private[paiges] case class Union(a: Doc, b: Doc) extends Doc
 

--- a/core/src/test/scala/org/typelevel/paiges/PaigesScalacheckTest.scala
+++ b/core/src/test/scala/org/typelevel/paiges/PaigesScalacheckTest.scala
@@ -1,13 +1,13 @@
 package org.typelevel.paiges
 
-import org.scalatest.FunSuite
-import org.scalatest.prop.PropertyChecks._
 import org.scalacheck.Gen
+import org.scalatest.prop.PropertyChecks._
+import org.scalatest.{ Assertion, FunSuite }
 
 class PaigesScalacheckTest extends FunSuite {
-  import PaigesTest._
-  import Generators._
   import Doc.text
+  import Generators._
+  import PaigesTest._
 
   implicit val generatorDrivenConfig =
     PropertyCheckConfiguration(minSuccessful = 500)
@@ -211,25 +211,6 @@ class PaigesScalacheckTest extends FunSuite {
     }
   }
 
-  test("the left and right side of a union are the same after flattening") {
-    forAll { u: Doc.Union => assert(u.a.flatten === u.b.flatten) }
-  }
-
-  test("the left side of a union has a first line as long or longer than the right") {
-    forAll(Gen.choose(1, 200), genUnion) { (n, u) =>
-      def firstLine(d: Doc) = {
-        def loop(s: Stream[String], acc: List[String]): String =
-          s match {
-            case Stream.Empty => acc.reverse.mkString
-            case head #:: _ if head.contains('\n') => (head.takeWhile(_ != '\n') :: acc).reverse.mkString
-            case head #:: tail => loop(tail, head :: acc)
-          }
-        loop(d.renderStream(n), Nil)
-      }
-      assert(firstLine(u.a).length >= firstLine(u.b).length)
-    }
-  }
-
   test("a is flat ==> Concat(a, Union(b, c)) === Union(Concat(a, b), Concat(a, c))") {
     import Doc._
     forAll { (aGen: Doc, bc: Doc) =>
@@ -251,6 +232,48 @@ class PaigesScalacheckTest extends FunSuite {
           assert(Concat(d, c) === Union(Concat(a, c), Concat(b, c)))
         case _ =>
       }
+    }
+  }
+
+  test("Union invariant: `a.flatten == b.flatten`") {
+    forAll { d: Doc.Union => assert(d.a.flatten === d.b.flatten) }
+  }
+
+  test("Union invariant: `a != b`") {
+    forAll { d: Doc.Union => assert(d.a !== d.b) }
+  }
+
+  def unionRightAssocInvariant(d: Doc): Assertion = {
+    import Doc._
+    d match {
+      case Empty | Text(_) | Line(_) => assert(true)
+      case Concat(Concat(_, _), _) => assert(false, s"Left-associative Concat: ${d}")
+      case Concat(a, b) =>
+        unionRightAssocInvariant(a)
+        unionRightAssocInvariant(b)
+      case Union(a, _) => unionRightAssocInvariant(a)
+      case LazyDoc(f) => unionRightAssocInvariant(f.evaluated)
+      case Align(d) => unionRightAssocInvariant(d)
+      case Nest(_, d) => unionRightAssocInvariant(d)
+    }
+  }
+
+  test("Union invariant: `a` has right-associated `Concat` nodes") {
+    forAll { d: Doc.Union => unionRightAssocInvariant(d.a) }
+  }
+
+  test("Union invariant: the first line of `a` is at least as long as the first line of `b`") {
+    forAll(Gen.choose(1, 200), genUnion) { (n, u) =>
+      def firstLine(d: Doc) = {
+        def loop(s: Stream[String], acc: List[String]): String =
+          s match {
+            case Stream.Empty => acc.reverse.mkString
+            case head #:: _ if head.contains('\n') => (head.takeWhile(_ != '\n') :: acc).reverse.mkString
+            case head #:: tail => loop(tail, head :: acc)
+          }
+        loop(d.renderStream(n), Nil)
+      }
+      assert(firstLine(u.a).length >= firstLine(u.b).length)
     }
   }
 


### PR DESCRIPTION
This change came about when I was trying to understand the `Union`
invariants.  I changed some wording that I thought could be made more
clear, grouped the tests for `Union` invariants together, and added
two new ones that correspond to the invariants described in the
comments.