### PR TITLE
Maintain `Union` invariants in `fill`

### DIFF
--- a/core/src/main/scala/org/typelevel/paiges/Doc.scala
+++ b/core/src/main/scala/org/typelevel/paiges/Doc.scala
@@ -576,19 +576,22 @@ object Doc {
   /**
    * Represents an optimistic rendering (on the left) as well as a
    * fallback rendering (on the right) if the first line of the left
-   * is too long.
+   * is too long.  In `Union(a, b)`, we have the invariants:
    *
-   * There is an additional invariant on Union: `flatten(a) == flatten(b)`.
+   * - `a.flatten == b.flatten`
+   * - `a != b` (otherwise the Union would be redundant)
+   * - `a` is 2-right-associated with respect to `Concat` nodes to maintain efficiency in rendering.
+   * - The first line of `a` is longer than the first line of `b` at all widths.
    *
-   * By construction all `Union` nodes have this property; to preserve
+   * A `Doc` is 2-right-associated if there are no subterms of the form
+   * `Concat(Concat(Concat(_, _), _), _)`.  Due to how `fill` is implemented,
+   * subterms of the form `Concat(Concat(_, _), _)` can appear, but as long
+   * as the left-associated chains are not very long, we avoid the potentially
+   * quadratic behavior of unconstrained terms.
+   *
+   * By construction all `Union` nodes have these properties; to preserve
    * this we don't expose the `Union` constructor directly, but only
-   * the `.grouped` method on Doc.
-   *
-   * Additionally, the left side (a) MUST be right associated with
-   * any Concat nodes to maintain efficiency in rendering. This
-   * is currently done by flatten/flattenOption.
-   *
-   * Finally, we have the invariant a != b.
+   * the `grouped` and `fill` methods.
    */
   private[paiges] case class Union(a: Doc, b: Doc) extends Doc
 

--- a/core/src/test/scala/org/typelevel/paiges/PaigesTest.scala
+++ b/core/src/test/scala/org/typelevel/paiges/PaigesTest.scala
@@ -31,6 +31,20 @@ object PaigesTest {
         .mkString("\n")
     }
   }
+
+  def twoRightAssociated(d: Doc): Boolean = {
+    import Doc._
+    d match {
+      case Empty | Text(_) | Line(_) => true
+      case Concat(Concat(Concat(_, _), _), _) => false
+      case Concat(a, b) =>
+        twoRightAssociated(a) && twoRightAssociated(b)
+      case Union(a, _) => twoRightAssociated(a)
+      case LazyDoc(f) => twoRightAssociated(f.evaluated)
+      case Align(d) => twoRightAssociated(d)
+      case Nest(_, d) => twoRightAssociated(d)
+    }
+  }
 }
 
 class PaigesTest extends FunSuite {


### PR DESCRIPTION
This change fixes invariants broken by `fill`, e.g. #112.  Note that using
`Concat` when making the `Union` is not sufficient, since flat `Doc`s can
be `Concat` nodes themselves, and thus we get left-associated `Concat` 
nodes all over the place in the existing code.  This fix locally associates them
without doing too much work.