### PR TITLE
DO NOT MERGE: Performance question

### DIFF
--- a/core/src/main/scala/org/typelevel/paiges/Chunk.scala
+++ b/core/src/main/scala/org/typelevel/paiges/Chunk.scala
@@ -3,109 +3,101 @@ package org.typelevel.paiges
 import scala.annotation.tailrec
 
 private[paiges] object Chunk {
+  final class Thunk[A](x: () => A) {
+    lazy val force: A = x()
+  }
+
+  sealed trait ChunkStream extends Product with Serializable
+
+  object ChunkStream {
+    case object Empty extends ChunkStream
+    case class Text(s: String, tail: Thunk[ChunkStream]) extends ChunkStream
+    case class Line(pos: Int, tail: Thunk[ChunkStream]) extends ChunkStream
+  }
+
+  class ChunkIterator(var current: ChunkStream) extends Iterator[String] {
+    def hasNext: Boolean = current != ChunkStream.Empty
+    def next: String = current match {
+      case ChunkStream.Text(s, tail) =>
+        current = tail.force
+        s
+      case ChunkStream.Line(pos, tail) =>
+        current = tail.force
+        lineToStr(pos)
+      case ChunkStream.Empty => throw new RuntimeException("next called on empty iterator")
+    }
+  }
+
+  class TrimChunkIterator(var current: ChunkStream) extends Iterator[String] {
+    private val lineCombiner = new TrimChunkIterator.LineCombiner
+    def hasNext: Boolean = current != ChunkStream.Empty || lineCombiner.nonEmpty
+    def next: String = current match {
+      case ChunkStream.Empty => lineCombiner.finalLine()
+      case ChunkStream.Text(s, tail) =>
+        current = tail.force
+        lineCombiner.addText(s)
+        next
+      case ChunkStream.Line(pos, tail) =>
+        current = tail.force
+        lineCombiner.addLine(pos)
+    }
+  }
+
+  object TrimChunkIterator {
+    class LineCombiner {
+      private var line: StringBuilder = new StringBuilder
+      def nonEmpty: Boolean = line.nonEmpty
+      def finalLine(): String = {
+        val res = line.toString
+        line = new StringBuilder
+        LineCombiner.trim(res)
+      }
+      def addText(s: String): Unit = {
+        val _ = line.append(s)
+        ()
+      }
+      def addLine(pos: Int): String = {
+        val v = LineCombiner.trim(line.toString)
+        line = new StringBuilder(lineToStr(pos))
+        v
+      }
+    }
+    object LineCombiner {
+      private def trim(s: String): String = {
+        var ind = s.length
+        while (ind >= 1 && s.charAt(ind - 1) == ' ') ind = ind - 1
+        s.substring(0, ind)
+      }
+    }
+  }
+
+  @tailrec
+  def fits(width: Int, d: ChunkStream): Boolean =
+    (width >= 0) && {
+      d match {
+        case ChunkStream.Empty | ChunkStream.Line(_, _) => true
+        case ChunkStream.Text(s, tail) =>
+          val n = s.length
+          fits(width - n, tail.force)
+      }
+    }
 
   /**
    * Given a width and Doc find the Iterator
    * of Chunks.
    */
   def best(w: Int, d: Doc, trim: Boolean): Iterator[String] = {
-
     val nonNegW = w max 0
 
-    sealed abstract class ChunkStream
-    object ChunkStream {
-      case object Empty extends ChunkStream
-      case class Item(str: String, position: Int, stack: List[(Int, Doc)]) extends ChunkStream {
-        def isLine: Boolean = str == null
-        def stringChunk: String = if (isLine) lineToStr(position) else str
-        private[this] var next: ChunkStream = _
-        def step: ChunkStream = {
-          // do a cheap local computation.
-          // lazy val is thread-safe, but more expensive
-          // since everything is immutable here, this is
-          // safe
-          val res = next
-          if (res != null) res
-          else {
-            val c = loop(position, stack)
-            next = c
-            c
-          }
-        }
-      }
-    }
-
-    class ChunkIterator(var current: ChunkStream) extends Iterator[String] {
-      def hasNext: Boolean = (current != ChunkStream.Empty)
-      def next: String = {
-        val item = current.asInstanceOf[ChunkStream.Item]
-        val res = item.stringChunk
-        current = item.step
-        res
-      }
-    }
-
-    class TrimChunkIterator(var current: ChunkStream) extends Iterator[String] {
-      private val lineCombiner = new TrimChunkIterator.LineCombiner
-      def hasNext: Boolean = current != ChunkStream.Empty || lineCombiner.nonEmpty
-      def next: String = current match {
-        case ChunkStream.Empty => lineCombiner.finalLine()
-        case item: ChunkStream.Item =>
-          current = item.step
-          lineCombiner.addItem(item) getOrElse next
-      }
-    }
-
-    object TrimChunkIterator {
-      class LineCombiner {
-        private var line: StringBuilder = new StringBuilder
-        def nonEmpty: Boolean = line.nonEmpty
-        def finalLine(): String = {
-          val res = line.toString
-          line = new StringBuilder
-          LineCombiner.trim(res)
-        }
-        def addItem(item: ChunkStream.Item): Option[String] =
-          if (item.isLine) {
-            val v = LineCombiner.trim(line.toString)
-            line = new StringBuilder(lineToStr(item.position))
-            Some(v)
-          } else {
-            line.append(item.str)
-            None
-          }
-      }
-      object LineCombiner {
-        private def trim(s: String) = {
-          var ind = s.length
-          while (ind >= 1 && s.charAt(ind - 1) == ' ') ind = ind - 1
-          s.substring(0, ind)
-        }
-      }
-    }
-
-    @tailrec
-    def fits(pos: Int, d: ChunkStream): Boolean =
-      (nonNegW >= pos) && {
-        d match {
-          case ChunkStream.Empty => true
-          case item: ChunkStream.Item =>
-            item.isLine || fits(item.position, item.step)
-        }
-      }
-    /*
-     * This is not really tail recursive but many branches are, so
-     * we cheat below in non-tail positions
-     */
     @tailrec
     def loop(pos: Int, lst: List[(Int, Doc)]): ChunkStream = lst match {
       case Nil => ChunkStream.Empty
       case (i, Doc.Empty) :: z => loop(pos, z)
       case (i, Doc.Concat(a, b)) :: z => loop(pos, (i, a) :: (i, b) :: z)
-      case (i, Doc.Nest(j, d)) :: z => loop(pos, ((i + j), d) :: z)
+      case (i, Doc.Nest(j, d)) :: z => loop(pos, (i + j, d) :: z)
       case (_, Doc.Align(d)) :: z => loop(pos, (pos, d) :: z)
-      case (i, Doc.Text(s)) :: z => ChunkStream.Item(s, pos + s.length, z)
-      case (i, Doc.Line(_)) :: z => ChunkStream.Item(null, i, z)
+      case (i, Doc.Text(s)) :: z => ChunkStream.Text(s, new Thunk(() => loop(pos + s.length, z)))
+      case (i, Doc.Line(_)) :: z => ChunkStream.Line(i, new Thunk(() => loop(i, z)))
       case (i, Doc.LazyDoc(d)) :: z => loop(pos, (i, d.evaluated) :: z)
       case (i, Doc.Union(x, y)) :: z =>
         /*
@@ -118,12 +110,10 @@ private[paiges] object Chunk {
          * always has a 2-right-associated Doc which means it is O(w)
          * to find if you can fit in width w.
          */
-        if (fits(pos, first)) first
+        if (fits(nonNegW - pos, first)) first
         else loop(pos, (i, y) :: z)
     }
-
-    def cheat(pos: Int, lst: List[(Int, Doc)]) =
-      loop(pos, lst)
+    def cheat(pos: Int, lst: List[(Int, Doc)]): ChunkStream = loop(pos, lst)
 
     val stream = loop(0, (0, d) :: Nil)
     if (trim) new TrimChunkIterator(stream) else new ChunkIterator(stream)


### PR DESCRIPTION
I was trying to modify the chunking algorithm with an attempt at a `Fail` constructor, and I got a little bogged down by the implementation, which has 3 mutually recursive functions, one of which uses mutation to update the stream.  I decided to just try the simpler thing where we'd convert the `Doc` into a text/line stream, and render that in an immutable way.  

The change is straightforward, and removes all the mutual recursion, but of course is slower.  Around 50%-70% slower from just running the benchmarker.  I have a couple questions:

1. Could some Scala expert give some intuition on why it's so much worse?  Is it all the extra allocations for `Thunk`s?  I'm relatively new to Scala, and don't have a good sense of this.  

2. I tried marking `loop` in `best` as `@tailrec`, but it complained about the `loop` in the `Thunk`s.  (I had to change them to `cheat`.)  Since they're in a call-by-name position, I wouldn't think the compiler would consider them as a non-tail-call.  I tried changing `Thunk` to take `() => A`, and that didn't work either.  I maybe have a different understanding of what a tail call is, but I wouldn't think putting a call in a data structure would qualify as a non-tail-call.  What am I getting wrong?

Thank you!