### PR TITLE
Remove unnecessary version.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -183,7 +183,7 @@ lazy val commonNativeSettings = Seq(
 
 def previousArtifact(version: String, proj: String) = {
   // the "-dbuild..." part is for Scala community build friendliness
-  val regex = "0\\.([0-9]+)\\.[0-9]+(-SNAPSHOT|-dbuild[a-z0-9]*)?".r
+  val regex = "0\\.([0-9]+)\\.[0-9]+(-SNAPSHOT|-dbuild[a-z0-9]*|\\+.*)?".r
   version match {
     case regex("1", _) => Set("org.typelevel" %% s"paiges-$proj" % "0.1.0")
     case regex("2", _) => Set.empty[ModuleID]

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "0.2.2-SNAPSHOT"


### PR DESCRIPTION
The version number is now derived from the git commit.