### PR TITLE
Improve LazyDoc a bit

### DIFF
--- a/core/src/main/scala/org/typelevel/paiges/Chunk.scala
+++ b/core/src/main/scala/org/typelevel/paiges/Chunk.scala
@@ -106,7 +106,7 @@ private[paiges] object Chunk {
       case (_, Doc.Align(d)) :: z => loop(pos, (pos, d) :: z)
       case (_, Doc.Text(s)) :: z => ChunkStream.Item(s, pos + s.length, z)
       case (i, Doc.Line(_)) :: z => ChunkStream.Item(null, i, z)
-      case (i, Doc.LazyDoc(d)) :: z => loop(pos, (i, d.evaluated) :: z)
+      case (i, d@Doc.LazyDoc(_)) :: z => loop(pos, (i, d.evaluated) :: z)
       case (i, Doc.Union(x, y)) :: z =>
         /*
          * If we can fit the next line from x, we take it.

--- a/core/src/main/scala/org/typelevel/paiges/Doc.scala
+++ b/core/src/main/scala/org/typelevel/paiges/Doc.scala
@@ -572,17 +572,21 @@ object Doc {
     // This is never a LazyDoc
     lazy val evaluated: Doc = {
       @tailrec
-      def loop(d: Doc, toSet: List[LazyDoc]): Doc =
+      def loop(d: Doc, toUpdate: List[LazyDoc]): Doc =
         d match {
           case lzy@LazyDoc(thunk) =>
-            // this points to another, and therefore equivalent LazyDoc
+            // note: we are intentionally shadowing thunk here because
+            // we want to make it impossible to accidentally use the outer
+            // thunk
+            //
+            // lzy points to another, and therefore equivalent LazyDoc
             // short circuit if we this has already computed
             val lzyC = lzy.computed
             // lzy isn't computed, add it to the list of LazyDocs to fill in
-            if (lzyC == null) loop(thunk(), lzy :: toSet)
-            else loop(lzyC, toSet)
+            if (lzyC == null) loop(thunk(), lzy :: toUpdate)
+            else loop(lzyC, toUpdate)
           case _ =>
-            toSet.foreach(_.computed = d)
+            toUpdate.foreach(_.computed = d)
             d
         }
 

--- a/core/src/test/scala/org/typelevel/paiges/Generators.scala
+++ b/core/src/test/scala/org/typelevel/paiges/Generators.scala
@@ -97,8 +97,7 @@ object Generators {
         // bias to simple stuff
         (6, doc0Gen),
         (1, ugen),
-        // TODO: replace this with recur when 117 lands
-        (1, Gen.lzy(genTree(depth - 1, withFill)).map(Doc.defer(_))),
+        (1, recur.map(Doc.defer(_))),
         (2, cgen),
         (1, fgen))
     } else {

--- a/core/src/test/scala/org/typelevel/paiges/Generators.scala
+++ b/core/src/test/scala/org/typelevel/paiges/Generators.scala
@@ -89,6 +89,8 @@ object Generators {
         // bias to simple stuff
         (6, doc0Gen),
         (1, ugen),
+        // TODO: replace this with recur when 117 lands
+        (1, Gen.lzy(genTree(depth - 1, withFill)).map(Doc.defer(_))),
         (2, cgen),
         (if (withFill) 1 else 0, fgen))
     } else {

--- a/core/src/test/scala/org/typelevel/paiges/PaigesScalacheckTest.scala
+++ b/core/src/test/scala/org/typelevel/paiges/PaigesScalacheckTest.scala
@@ -38,6 +38,13 @@ class PaigesScalacheckTest extends AnyFunSuite {
     }
   }
 
+  test("LazyDoc.evaluate never returns a LazyDoc") {
+    forAll { (a: Doc) =>
+      val ld = Doc.LazyDoc(() => a)
+      assert(!ld.evaluated.isInstanceOf[Doc.LazyDoc])
+    }
+  }
+
   test("writeTo works") {
     import java.io._
     forAll { (doc: Doc, w: Int) =>

--- a/core/src/test/scala/org/typelevel/paiges/PaigesTest.scala
+++ b/core/src/test/scala/org/typelevel/paiges/PaigesTest.scala
@@ -294,4 +294,26 @@ the spaces""")
     assert(doc.renderWideStream.mkString == "done")
     assert(count == 1)
   }
+
+  test("defer short circuits") {
+    var d1count = 0
+    val d1 = Doc.defer {
+      d1count += 1
+      Doc.empty
+    }
+
+    var d2count = 0
+    val d2 = Doc.defer {
+      d2count += 1
+      d1
+    }
+
+    d2.render(0)
+    assert(d1count == 1)
+    assert(d2count == 1)
+    // rendering d1 does not increment d1
+    d1.render(0)
+    assert(d1count == 1)
+    assert(d2count == 1)
+  }
 }

--- a/core/src/test/scala/org/typelevel/paiges/PaigesTest.scala
+++ b/core/src/test/scala/org/typelevel/paiges/PaigesTest.scala
@@ -41,7 +41,7 @@ object PaigesTest {
       case Concat(a, b) =>
         twoRightAssociated(a) && twoRightAssociated(b)
       case Union(a, _) => twoRightAssociated(a)
-      case LazyDoc(f) => twoRightAssociated(f.evaluated)
+      case f@LazyDoc(_) => twoRightAssociated(f.evaluated)
       case Align(d) => twoRightAssociated(d)
       case Nest(_, d) => twoRightAssociated(d)
     }
@@ -282,5 +282,16 @@ the spaces""")
 
   test("cat") {
     assert(Doc.cat(List("1", "2", "3") map Doc.text).render(80) == "123")
+  }
+
+  test("defer doesn't evaluate immediately") {
+    var count = 0
+    val doc = Doc.defer {
+      count += 1
+      Doc.text("done")
+    }
+    assert(count == 0)
+    assert(doc.renderWideStream.mkString == "done")
+    assert(count == 1)
   }
 }


### PR DESCRIPTION
This adds two tests to LazyDoc and improves LazyDoc such that evaluated tail recursively fully evaluated the lazy doc into a non lazy doc. If we pass through another LazyDoc, we evaluate that as well.