### PR TITLE
WIP: simplify fill implementation

### DIFF
--- a/core/src/test/scala/org/typelevel/paiges/PaigesScalacheckTest.scala
+++ b/core/src/test/scala/org/typelevel/paiges/PaigesScalacheckTest.scala
@@ -333,8 +333,8 @@ class PaigesScalacheckTest extends AnyFunSuite {
       n <- Gen.choose(1, 10)
       ds <- Gen.listOfN(n, genDoc)
     } yield ds
-    forAll(docsGen) { ds: List[Doc] =>
-      assert(Doc.fill(Doc.line, ds) === fillSpec(ds))
+    forAll(genDoc, docsGen) { (sep: Doc, ds: List[Doc]) =>
+      assert(Doc.fill(sep, ds) === fillSpec(sep, ds))
     }
   }
 }

--- a/core/src/test/scala/org/typelevel/paiges/PaigesTest.scala
+++ b/core/src/test/scala/org/typelevel/paiges/PaigesTest.scala
@@ -48,15 +48,15 @@ object PaigesTest {
   }
 
   // Definition of `fill` from the paper
-  def fillSpec(ds: List[Doc]): Doc = {
+  def fillSpec(sep: Doc, ds: List[Doc]): Doc = {
     import Doc._
     ds match {
       case Nil => empty
       case x :: Nil => x.grouped
       case x :: y :: zs =>
         Union(
-          x.flatten + (space + fillSpec(y.flatten :: zs)),
-          x + (line + fillSpec(y :: zs))
+          x.flatten + (sep.flatten + fillSpec(sep, y.flatten :: zs)),
+          x + (sep + fillSpec(sep, y :: zs))
         )
     }
   }


### PR DESCRIPTION
fill is one of the main combinators that is complicated by having a hardLine for two reasons:

1. Union is only created in two places: grouped and fill. fill is much more complex (a naive implementation would be exponential).
2. we have a very complicated implementation to make it stack safe.

It occurs to me, we could greatly simplify using defer and it is only a bit slower:
```
[info] Benchmark                    (size)   Mode  Cnt   Score    Error   Units
[info] PaigesBenchmark.fill100         100  thrpt    3  44.600 ± 67.349  ops/ms
[info] PaigesBenchmark.fill100        1000  thrpt    3   4.585 ±  1.628  ops/ms
[info] PaigesBenchmark.fill100       10000  thrpt    3   0.500 ±  0.252  ops/ms
[info] PaigesBenchmark.fillSpec100     100  thrpt    3  33.180 ± 22.547  ops/ms
[info] PaigesBenchmark.fillSpec100    1000  thrpt    3   3.568 ±  1.130  ops/ms
[info] PaigesBenchmark.fillSpec100   10000  thrpt    3   0.376 ±  0.494  ops/ms
```
so the simpler implementation is about 75% as fast.

One problem with this implementation is that if the separator does not have line in it we are in a very bad case, but if you don't have a line in the fill sep, then you have an exponentially bad time searching for a fit.

cc @seanmcl 