### PR TITLE
Fix cats build, add Defer for Document

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -83,7 +83,7 @@ lazy val coreJS = core.js
 lazy val coreNative = core.native
 
 lazy val cats = crossProject(JSPlatform, JVMPlatform)
-  .crossType(CrossType.Pure)
+  .crossType(CrossType.Full)
   .in(file("cats"))
   .dependsOn(core % "compile->compile;test->test")
   .settings(
@@ -92,11 +92,14 @@ lazy val cats = crossProject(JSPlatform, JVMPlatform)
     moduleName := "paiges-cats",
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "cats-core" % "2.0.0",
-      "org.typelevel" %%% "cats-laws" % "2.0.0" % Test),
+      "org.typelevel" %%% "cats-laws" % "2.0.0" % "test",
+      "org.typelevel" %%% "discipline-scalatest" % "1.0.0-M1" % "test"
+      ),
     mimaPreviousArtifacts := previousArtifact(version.value, "cats"))
   .disablePlugins(JmhPlugin)
   .jsSettings(commonJsSettings)
   .jvmSettings(commonJvmSettings)
+
 lazy val catsJVM = cats.jvm
 lazy val catsJS = cats.js
 

--- a/cats/shared/src/main/scala/org/typelevel/paiges/CatsDocument.scala
+++ b/cats/shared/src/main/scala/org/typelevel/paiges/CatsDocument.scala
@@ -1,7 +1,6 @@
 package org.typelevel.paiges
 
-import cats.Semigroupal
-import cats.Contravariant
+import cats.{ Contravariant, Defer, Semigroupal}
 
 trait CatsDocument {
   implicit val contravariantDocument: Contravariant[Document] =
@@ -15,6 +14,12 @@ trait CatsDocument {
         Document.instance { case (a, b) =>
           fa.document(a) + sep + fb.document(b)
         }
+    }
+
+  implicit val deferDocument: Defer[Document] =
+    new Defer[Document] {
+      def defer[A](d: => Document[A]): Document[A] =
+        Document.defer(d)
     }
 }
 

--- a/cats/shared/src/test/scala/org/typelevel/paiges/LawTests.scala
+++ b/cats/shared/src/test/scala/org/typelevel/paiges/LawTests.scala
@@ -3,7 +3,7 @@ package org.typelevel.paiges
 import cats.Semigroupal
 import cats.Contravariant
 import cats.kernel.{Eq, Monoid}
-import cats.laws.discipline.{ExhaustiveCheck, SemigroupalTests, ContravariantTests, SerializableTests}
+import cats.laws.discipline.{ExhaustiveCheck, SemigroupalTests, ContravariantTests, SerializableTests, DeferTests}
 import cats.kernel.laws.discipline.MonoidTests
 import cats.laws.discipline.eq.catsLawsEqForFn1Exhaustive
 
@@ -12,6 +12,7 @@ import org.scalacheck.Arbitrary
 import org.scalactic.anyvals.{PosZDouble, PosInt, PosZInt}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.prop.Configuration
+
 
 class LawTests extends LawChecking with CatsDocument {
   import org.typelevel.paiges.Generators._
@@ -30,10 +31,14 @@ class LawTests extends LawChecking with CatsDocument {
   implicit def eqForDocument[A: ExhaustiveCheck]: Eq[Document[A]] =
     Eq.by[Document[A], A => Doc](inst => (a: A) => inst.document(a))
 
+  implicit val eqBool: Eq[Boolean] =
+    Eq.instance[Boolean](_ == _)
+
   checkAll("Monoid[Doc]", MonoidTests[Doc].monoid)
 
   checkAll("Contravariant[Document]", ContravariantTests[Document].contravariant[Boolean, Boolean, Boolean])
   checkAll("Contravariant[Document]", SerializableTests.serializable(Contravariant[Document]))
+  checkAll("Defer[Document]", DeferTests[Document].defer[Boolean])
 
   {
     implicit val semigroupalDocument: Semigroupal[Document] =


### PR DESCRIPTION
PR #160 had a mistake with running the cats laws and we haven't been running them.

This fixes that, and adds an instance of Defer for Document.