### PR TITLE
Replace Stream[A] with LazyIterable[A].

### DIFF
--- a/core/src/main/scala/org/typelevel/paiges/LazyIterable.scala
+++ b/core/src/main/scala/org/typelevel/paiges/LazyIterable.scala
@@ -1,0 +1,37 @@
+package org.typelevel.paiges
+
+sealed abstract class LazyIterable[+A] extends Iterable[A] {
+  def iterator: Iterator[A] =
+    this match {
+      case LazyIterable.Empty =>
+        Iterator.empty
+      case cons @ LazyIterable.Cons(_, _) =>
+        new Iterator[A] {
+          var xs: LazyIterable.Cons[A] = cons
+          def hasNext: Boolean = xs != null
+          def next: A = {
+            val res = xs.head
+            xs = xs.continue() match {
+              case next @ LazyIterable.Cons(_, _) => next
+              case LazyIterable.Empty => null
+            }
+            res
+          }
+        }
+    }
+}
+
+object LazyIterable {
+
+  case object Empty extends LazyIterable[Nothing]
+
+  case class Cons[+A](override val head: A, continue: () => LazyIterable[A]) extends LazyIterable[A]
+
+  def empty[A]: LazyIterable[A] = Empty
+
+  def cons[A](head: A, tail: => LazyIterable[A]): LazyIterable[A] =
+    Cons(head, tail _)
+
+  def fromIterator[A](it: Iterator[A]): LazyIterable[A] =
+    if (it.hasNext) Cons(it.next, () => fromIterator(it)) else Empty
+}

--- a/core/src/test/scala/org/typelevel/paiges/PaigesScalacheckTest.scala
+++ b/core/src/test/scala/org/typelevel/paiges/PaigesScalacheckTest.scala
@@ -301,11 +301,14 @@ class PaigesScalacheckTest extends OurFunSuite {
   test("Union invariant: the first line of `a` is at least as long as the first line of `b`") {
     forAll(Gen.choose(1, 200), genUnion) { (n, u) =>
       def firstLine(d: Doc) = {
-        def loop(s: Stream[String], acc: List[String]): String =
+        def loop(s: LazyIterable[String], acc: List[String]): String =
           s match {
-            case Stream.Empty => acc.reverse.mkString
-            case head #:: _ if head.contains('\n') => (head.takeWhile(_ != '\n') :: acc).reverse.mkString
-            case head #:: tail => loop(tail, head :: acc)
+            case LazyIterable.Empty =>
+              acc.reverse.mkString
+            case LazyIterable.Cons(head, _) if head.contains('\n') =>
+              (head.takeWhile(_ != '\n') :: acc).reverse.mkString
+            case LazyIterable.Cons(a, continue) =>
+              loop(continue(), a :: acc)
           }
         loop(d.renderStream(n), Nil)
       }


### PR DESCRIPTION
We don't need many of the features Stream provides (e.g. memoization),
so we can replace it with a very simple implementation that extends
Iterable. We also don't need to ensure that combinators such as map
are lazy, because we build these things up lazily but then take them
apart eagerly in most cases.

I'm open to adding more features to LazyIterable if we _do_ want to
make it a production-ready collection type. For now it's the smallest
thing I thought we could replace Stream with.