### PR TITLE
Use sbt tricks to use LazyList in 2.13, Stream before that

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,19 @@ val Scala211 = "2.11.12"
 val Scala212 = "2.12.8"
 val Scala213 = "2.13.0"
 
+def scalaVersionSpecificFolders(srcName: String, srcBaseDir: java.io.File, scalaVersion: String) = {
+  def extraDirs(suffix: String) =
+    List(CrossType.Pure, CrossType.Full)
+      .flatMap(_.sharedSrcDir(srcBaseDir, srcName).toList.map(f => file(f.getPath + suffix)))
+  CrossVersion.partialVersion(scalaVersion) match {
+    case Some((2, y)) if y <= 12 =>
+      extraDirs("-2.12-")
+    case Some((2, y)) if y >= 13 =>
+      extraDirs("-2.13+")
+    case _ => Nil
+  }
+}
+
 inThisBuild(List(
   organization := "org.typelevel",
   scalaVersion := Scala213,
@@ -164,7 +177,9 @@ lazy val commonSettings = Seq(
       case _ =>
         Nil
     }
-  )
+  ),
+  Compile / unmanagedSourceDirectories ++= scalaVersionSpecificFolders("main", baseDirectory.value, scalaVersion.value),
+  Test / unmanagedSourceDirectories ++= scalaVersionSpecificFolders("test", baseDirectory.value, scalaVersion.value)
 )
 
 lazy val commonJvmSettings = Seq(

--- a/core/src/main/scala-2.12-/org/typelevel/paiges/ScalaVersionCompat.scala
+++ b/core/src/main/scala-2.12-/org/typelevel/paiges/ScalaVersionCompat.scala
@@ -1,0 +1,9 @@
+package org.typelevel.paiges
+
+object ScalaVersionCompat {
+  type LazyList[+A] = scala.collection.immutable.Stream[A]
+  val LazyList = scala.collection.immutable.Stream
+
+  def lazyListFromIterator[A](it: Iterator[A]): LazyList[A] =
+    it.toStream
+}

--- a/core/src/main/scala-2.13+/org/typelevel/paiges/ScalaVersionCompat.scala
+++ b/core/src/main/scala-2.13+/org/typelevel/paiges/ScalaVersionCompat.scala
@@ -1,0 +1,6 @@
+package org.typelevel.paiges
+
+object ScalaVersionCompat {
+  def lazyListFromIterator[A](it: Iterator[A]): LazyList[A] =
+    LazyList.from(it)
+}

--- a/core/src/test/scala/org/typelevel/paiges/PaigesScalacheckTest.scala
+++ b/core/src/test/scala/org/typelevel/paiges/PaigesScalacheckTest.scala
@@ -303,13 +303,14 @@ class PaigesScalacheckTest extends OurFunSuite {
   test("Union invariant: the first line of `a` is at least as long as the first line of `b`") {
     forAll(Gen.choose(1, 200), genUnion) { (n, u) =>
       def firstLine(d: Doc) = {
-        def loop(s: Stream[String], acc: List[String]): String =
-          s match {
-            case Stream.Empty => acc.reverse.mkString
-            case head #:: _ if head.contains('\n') => (head.takeWhile(_ != '\n') :: acc).reverse.mkString
-            case head #:: tail => loop(tail, head :: acc)
+        def loop(s: Iterator[String], acc: List[String]): String =
+          if (!s.hasNext) acc.reverse.mkString
+          else {
+            val head = s.next
+            if (head.contains('\n')) { (head.takeWhile(_ != '\n') :: acc).reverse.mkString }
+            else loop(s, head :: acc)
           }
-        loop(d.renderStream(n), Nil)
+        loop(d.renderStream(n).iterator, Nil)
       }
       assert(firstLine(u.a).length >= firstLine(u.b).length)
     }


### PR DESCRIPTION
close #182 

This uses an sbt trick from cats to add some directories that are conditionally compiled on different versions of scala. The idea is that you make that object source compatible assuming the scala standard library.