### PR TITLE
Update sbt-github-action worklows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,8 +116,6 @@ jobs:
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
-      - run: sbt ++${{ matrix.scala }} ci-release
-
   checks:
     name: Format Scala code
     strategy:

--- a/build.sbt
+++ b/build.sbt
@@ -64,6 +64,8 @@ ThisBuild / githubWorkflowAddedJobs ++= Seq(
 
 ThisBuild / githubWorkflowArtifactUpload := false
 
+ThisBuild / githubWorkflowPublish := Seq()
+
 ThisBuild / githubWorkflowTargetTags ++= Seq("v*")
 ThisBuild / githubWorkflowPublishTargetBranches :=
   Seq(RefPredicate.StartsWith(Ref.Tag("v")))


### PR DESCRIPTION
The previous commit didn't run `sbt githubWorkflowGenerate`. This commit
fixes that so that the CI becomes green again.