### PR TITLE
Migrate to mdoc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Validate JVM (scala 2)
         if: matrix.platform == 'jvm' && matrix.scala == '2.12.12'
-        run: sbt ++${{ matrix.scala }} coverage jvm/checkCI docs/tut coverageReport
+        run: sbt ++${{ matrix.scala }} coverage jvm/checkCI docs/mdoc coverageReport
 
       - name: Upload Codecov Results
         if: matrix.platform == 'jvm' && matrix.scala == '2.12.12'

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ ThisBuild / githubWorkflowBuild := Seq(
                    name = Some("Setup codecov"),
                    cond = Some(JvmCond + " && " + Scala212Cond)
   ),
-  WorkflowStep.Sbt(List("coverage", "jvm/checkCI", "docs/tut", "coverageReport"),
+  WorkflowStep.Sbt(List("coverage", "jvm/checkCI", "docs/mdoc", "coverageReport"),
                    name = Some("Validate JVM (scala 2)"),
                    cond = Some(JvmCond + " && " + Scala212Cond)
   ),
@@ -192,12 +192,13 @@ lazy val benchmark = project
 lazy val docs = project
   .in(file("docs"))
   .dependsOn(coreJVM, catsJVM)
-  .enablePlugins(TutPlugin)
+  .enablePlugins(MdocPlugin)
   .settings(
     noPublish,
     crossScalaVersions := List(Scala212),
     name := "paiges-docs",
-    scalacOptions in Tut := {
+    mdocIn := baseDirectory.in(LocalRootProject).value / "docs" / "src" / "main" / "mdoc",
+    scalacOptions in mdoc := {
       val testOptions = scalacOptions.in(test).value
       val unwantedOptions = Set("-Xlint", "-Xfatal-warnings")
       testOptions.filterNot(unwantedOptions)

--- a/docs/src/main/mdoc/intro.md
+++ b/docs/src/main/mdoc/intro.md
@@ -8,7 +8,7 @@ Paiges is an implementation of Philip Wadler's
 To get started, you'll want to import `Doc`. This is the basis for
 Paiges, and is likely the only type you'll need to work with:
 
-```tut:book
+```scala mdoc
 import org.typelevel.paiges.Doc
 ```
 
@@ -18,7 +18,7 @@ Many documents are defined in terms of other documents, but to get
 started you'll need to create documents to represent chunks of text.
 Here are three good ways to do it.
 
-```tut:book
+```scala mdoc
 // unbroken text from a String
 val cat = Doc.text("cat")
 
@@ -34,7 +34,7 @@ val doc = Doc.paragraph(
 
 We can use a single line of text to contrast these methods:
 
-```tut:silent
+```scala mdoc:silent
 val howl = "I saw the best minds of my generation destroyed by madness..."
 ```
 
@@ -42,14 +42,14 @@ The first two, `Doc.text` and `Doc.str`, create a fragment of text that
 will always render exactly as shown. This means that if you create a
 very long piece of text, it won't be wrapped to fit smaller widths.
 
-```tut:book
+```scala mdoc
 Doc.text(howl).render(40)
 ```
 
 By contrast, `Doc.paragraph` will add line breaks to make the document
 fit:
 
-```tut:book
+```scala mdoc
 Doc.paragraph(howl).render(40)
 ```
 
@@ -85,7 +85,7 @@ allows Paiges to render at different widths so efficiently.
 Documents are concatenation with `+`. As a convenience, Paiges also
 provides `+:` and `:+` to prepend or append a string.
 
-```tut:book
+```scala mdoc
 val doc1 = Doc.text("my pet is a ") + Doc.text("cat")
 val doc2 = Doc.text("my pet is a ") :+ "cat"
 val doc3 = "my pet is a " +: Doc.text("cat")
@@ -103,7 +103,7 @@ There are also several other types of concatenation (which can all be
 written in terms of `+`). For example, `/` concatenates documents with
 a newline in between:
 
-```tut:book
+```scala mdoc
 // equivalent to Doc.text("first line") + Doc.line + Doc.text("second line")
 val doc5 = Doc.text("first line")  / Doc.text("second line")
 val doc6 = Doc.text("first line")  :/ "second line"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.8.1")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.5.1")
-addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.6.13")
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.19" )
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.7")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")


### PR DESCRIPTION
Resolves https://github.com/typelevel/paiges/issues/339
This PR does a pretty naive migration of `tut` to `mdoc`.

Some differences in output:

### tut

```scala
// unbroken text from a String
val cat = Doc.text("cat")
// cat: org.typelevel.paiges.Doc = Doc(...)

// same as text, but using .toString first
val pair = Doc.str((1, 2))
// pair: org.typelevel.paiges.Doc = Doc(...)
```

### mdoc

```scala
// unbroken text from a String
val cat = Doc.text("cat")
// cat: Doc = Text(str = "cat")

// same as text, but using .toString first
val pair = Doc.str((1, 2))
// pair: Doc = Text(str = "(1,2)")
```

It looks like we weren't using the output of tut anywhere in the previous build?
Maybe I am missing something... 🤔 